### PR TITLE
Bug: Fix writable

### DIFF
--- a/yateto/controlflow/graph.py
+++ b/yateto/controlflow/graph.py
@@ -46,6 +46,10 @@ class Variable(object):
     assert not isEq or (self.writable == other.writable and self._memoryLayout == other._memoryLayout)
     return isEq
 
+  def setWritable(self, name):
+    if self.name == name:
+      self.writable = True
+
 class Expression(object):
   def __init__(self, node, memoryLayout, variables):
     self.node = node
@@ -80,6 +84,10 @@ class Expression(object):
 
   def __str__(self):
     return '{}({})'.format(type(self.node).__name__, ', '.join([str(var) for var in self._variables]))
+
+  def setWritable(self, name):
+    for v in self._variables:
+      v.setWritable(name)
 
 class ProgramAction(object):
   def __init__(self, result, term, add, scalar = None):
@@ -122,10 +130,14 @@ class ProgramAction(object):
     tsubs = self.term.substituted(when, by, rsubs.memoryLayout()) if term else self.term
     return ProgramAction(rsubs, tsubs, self.add, self.scalar)
 
+  def setVariablesWritable(self, name):
+    self.result.setWritable(name)
+    self.term.setWritable(name)
+
 class ProgramPoint(object):
   def __init__(self, action):
     self.action = action
     self.live = None
     self.initBuffer = None
     self.bufferMap = None
-    
+

--- a/yateto/controlflow/visitor.py
+++ b/yateto/controlflow/visitor.py
@@ -66,7 +66,7 @@ class AST2ControlFlow(Visitor):
     return result
   
   def visit_Assign(self, node):
-    self._writable = self._writable | {node[0].name()}
+    self.updateWritable(node[0].name())
     variables = [self.visit(child) for child in node]
 
     rhs = self._addPermuteIfRequired(node.indices, node.rightTerm(), variables[1])
@@ -85,6 +85,13 @@ class AST2ControlFlow(Visitor):
     name = '{}{}'.format(self.TEMPORARY_RESULT, self._tmp)
     self._tmp += 1
     return Variable(name, True, self._ml(node), node.eqspp())
+
+  def updateWritable(self, name):
+    self._writable = self._writable | {name}
+    # Set variables writable that were added beforehand
+    for pp in self._cfg:
+      if pp.action:
+        pp.action.setVariablesWritable(name)
 
 class SortedGlobalsList(object):
   def visit(self, cfg):


### PR DESCRIPTION
Consider the sequence:
A <= ... B ...
B <= ...

Which is transformed to a control flow graph with
ast2cf = AST2ControlFlow()
for ast in self.ast:
  ast2cf.visit(ast)

B is not marked writable in the first call to ast2cf, but in the second. Therefore inconsistencies may arise which are fixed in this patch.