### PR TITLE
Nodal bc

### DIFF
--- a/include/yateto/TensorView.h
+++ b/include/yateto/TensorView.h
@@ -187,6 +187,11 @@ namespace yateto {
       DenseTensorView<nSlices, real_t, uint_t> subtensor(&operator[](begin), size, stride);
       return subtensor;
     }
+
+    real_t* data() {
+      return m_values;
+    }
+
   protected:
     void computeStride() {
       m_stride[0] = 1;

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -225,7 +225,7 @@ class OptimisedKernelGenerator(KernelGenerator):
             header.functionDeclaration(executeName(index))
 
         if familyStride is not None:
-          header('typedef void ({}::* const {})(void);'.format(name, self.MEMBER_FUNCTION_PTR_NAME))
+          header('using {} = void ({}::*)();'.format(self.MEMBER_FUNCTION_PTR_NAME, name))
           header('{} {} {}[] = {};'.format(
             MODIFIERS,
             self.MEMBER_FUNCTION_PTR_NAME,


### PR DESCRIPTION
Two changes:

1. Add data() getter to tensor views (simplifies some stuff a bit)
2. Change typedef for pointer -> old version results in warning in newer gcc versions