### PR TITLE
Fix #15

### DIFF
--- a/yateto/__init__.py
+++ b/yateto/__init__.py
@@ -2,3 +2,4 @@ from .type import *
 from .generator import NamespacedGenerator, Generator, simpleParameterSpace, parameterSpaceFromRanges
 from .arch import useArchitectureIdentifiedBy
 from .gemm_configuration import *
+from .memory import *

--- a/yateto/type.py
+++ b/yateto/type.py
@@ -1,7 +1,7 @@
 import re
 from .ast.node import Node, IndexedTensor
 from numpy import ndarray, zeros, float64
-from .memory import DenseMemoryLayout
+from .memory import DenseMemoryLayout, Alignment
 from . import aspp
 
 class AbstractType(object):
@@ -30,8 +30,8 @@ class Tensor(AbstractType):
   GROUP_INDICES = r'\(({0}(,{0})*)\)'.format(GROUP_INDEX)
   VALID_NAME = r'^{}({})?$'.format(BASE_NAME, GROUP_INDICES)
 
-  def __init__(self, name, shape, spp=None, memoryLayoutClass=DenseMemoryLayout, alignStride=False,
-               namespace=None):
+  def __init__(self, name, shape, spp=None, memoryLayoutClass=DenseMemoryLayout,
+               alignStride=Alignment.Automatic, namespace=None):
     if not isinstance(shape, tuple):
       raise ValueError('shape must be a tuple')
     
@@ -72,7 +72,7 @@ class Tensor(AbstractType):
     
     self.setMemoryLayout(memoryLayoutClass, alignStride)
 
-  def setMemoryLayout(self, memoryLayoutClass, alignStride=False):
+  def setMemoryLayout(self, memoryLayoutClass, alignStride=Alignment.Automatic):
     self._memoryLayout = memoryLayoutClass.fromSpp(self._groupSpp, alignStride=alignStride)
 
   def _setSparsityPattern(self, spp, setOnlyGroupSpp=False):
@@ -85,7 +85,7 @@ class Tensor(AbstractType):
 
   def setGroupSpp(self, spp):
     self._setSparsityPattern(spp, setOnlyGroupSpp=True)
-    self.setMemoryLayout(self._memoryLayout.__class__, alignStride=self._memoryLayout.alignedStride())
+    self.setMemoryLayout(self._memoryLayout.__class__, alignStride=self._memoryLayout.alignment())
 
   def __getitem__(self, indexNames):
     return IndexedTensor(self, indexNames)


### PR DESCRIPTION
When a tensor's stride is divisible by the vector width then memory is always assumed to be aligned. In some situations one might want to work with unaligned memory even if the stride is divisible by the vector width (e.g. when interfacing existing data structures without aligned memory allocation).

With this PR one may pass Alignment.Unaligned to the alignStride option to enforce unaligned memory access. The previous "False" value maps to Alignment.Automatic and the previous "True" value maps to Alignment.Aligned. Passing True and False is still ok such that existing code does not need to be changed.