### PR TITLE
Use .noalias() for eigen backend

### DIFF
--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -101,12 +101,11 @@ class Eigen(BLASlike):
           )
     code = ''
     if beta == 1.0:
-      code = '_mapC += {AxB};'.format(AxB=AxB)
+      code = '_mapC.noalias() += {AxB};'.format(AxB=AxB)
     elif beta == 0.0:
       code = '_mapC = {AxB};'.format(AxB=AxB)
     else:
-      code = '_mapC = {AxB} + {beta}*_mapC;'.format(AxB=AxB, beta=beta)
-
+      code = '_mapC *= {beta}; _mapC.noalias() += {AxB};'.format(AxB=AxB, beta=beta)
     code = """{{
   using Eigen::Matrix;
   using Eigen::Map;


### PR DESCRIPTION
We need to tell eigen that the matrix C does not alias with the other matrices.
This leads to a jump from 30% of peak on arm to 32 % (proxy).

More details:

## Peak Performance:

Per Processor: 2.2 Ghz * 2 (FP Units) * 2 (FMA) * 2 (128 bit simd) * 64 = 563,2 GFLOP/s
Per Node: 563.2 GFLOP/s * 2 = 1264,4 GFLOP/s
## Without .noalias():

seissol proxy mode                  : all
time for seissol proxy              : 0.948364

GFLOP (non-zero) for seissol proxy  : 126.776422
GFLOP (hardware) for seissol proxy  : 359.820000
GiB (estimate) for seissol proxy    : 22.999942

GFLOPS (non-zero) for seissol proxy : 133.679075
GFLOPS (hardware) for seissol proxy : 379.411281
GiB/s (estimate) for seissol proxy  : 24.252230

## With .noalias()

seissol proxy mode                  : all
time for seissol proxy              : 0.867208

GFLOP (non-zero) for seissol proxy  : 126.776422
GFLOP (hardware) for seissol proxy  : 359.820000
GiB (estimate) for seissol proxy    : 22.999942

GFLOPS (non-zero) for seissol proxy : 146.189175
GFLOPS (hardware) for seissol proxy : 414.917759
GiB/s (estimate) for seissol proxy  : 26.521829