### PR TITLE
Ravil/gpu streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 install_requires = ['numpy']
 
-extras = {'with_gpu_support': ['gemmforge==0.0.200']}
+extras = {'with_gpu_support': ['gemmforge==0.0.202']}
 
 setup(
     name="yateto",

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -90,7 +90,7 @@ def initializeWithZero(cpp, arch, result: TensorDescription, writeBB = None):
 class BatchedOperationsAux:
   NUM_ELEMENTS_NAME = 'numElements'
   EXTRA_OFFSET_NAME = 'extraOffset'
-
+  STREAM_PTR_NAME = 'streamPtr'
 
   def __init__(self, underlying_data_type):
     self.underlying_data_type = underlying_data_type

--- a/yateto/codegen/copyscaleadd/csa_gen.py
+++ b/yateto/codegen/copyscaleadd/csa_gen.py
@@ -92,7 +92,8 @@ class CopyScaleAddGenerator(object):
         args = [str(alpha),
                 aux.deduce_arg(d.term),
                 aux.deduce_arg(d.result),
-                BatchedOperationsAux.NUM_ELEMENTS_NAME]
+                BatchedOperationsAux.NUM_ELEMENTS_NAME,
+                BatchedOperationsAux.STREAM_PTR_NAME]
         cpp("{}({});".format(routine_name, ', '.join(args)))
 
         routineCache.addRoutine(routine_name, GemmForgeWriter(forge_generator))

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -68,6 +68,14 @@ class KernelFactory(object):
 
     self._freeList = []
 
+  def reset_stream(self):
+    if self._target == 'cpu':
+      pass
+    elif self._target == 'gpu':
+      self._cpp(f'{BatchedOperationsAux.STREAM_PTR_NAME} = nullptr;')
+    else:
+      raise RuntimeError('unknown compute target')
+
   def _indices(self, var):
     shape = var.memoryLayout().shape()
     return Indices(string.ascii_lowercase[:len(shape)], shape)

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -122,7 +122,8 @@ class GemmGen(object):
           args = [aux.deduce_arg(d.leftTerm, as_const=True),
                   aux.deduce_arg(d.rightTerm, as_const=True),
                   aux.deduce_arg(d.result, as_const=False),
-                  BatchedOperationsAux.NUM_ELEMENTS_NAME]
+                  BatchedOperationsAux.NUM_ELEMENTS_NAME,
+                  BatchedOperationsAux.STREAM_PTR_NAME]
           args_str = ', '.join(args)
 
           if not isinstance(d.alpha, float):

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -282,6 +282,7 @@ class OptimisedKernelGenerator(KernelGenerator):
         # containers with extra offsets for GPU-like computations
         if target == 'gpu':
           header(f'unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME} = 0;')
+          header(f'void *{BatchedOperationsAux.STREAM_PTR_NAME} = nullptr;')
 
           def generate_extra_offset_args(base_name_with_namespace, groups):
             prefix, base_name = Tensor.splitBasename(base_name_with_namespace)

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -164,6 +164,7 @@ class OptimisedKernelGenerator(KernelGenerator):
       factory = OptimisedKernelFactory(fcpp, self._arch, target)
       hwFlops, tmp_memory = super().generate(fcpp, cfg, factory, self._routineCache, gemm_cfg)
       factory.freeTmp()
+      factory.reset_stream()
       function = functionIO.getvalue()    
     return self.KernelOutline(nonZeroFlops,
                               hwFlops,


### PR DESCRIPTION
This effects only kernels generated for batched computations. 

Sometimes batches become very small 100's of elements e.g., neighbor integrals in SeisSol. Therefore, it might be beneficial to launch a few independent  kernels in parallel. Yateto just propagate stream pointers from SeisSol to GemmForge. SeisSol controls which stream to assign to a kernel. If SeisSol doesn't assign a pointer to a stream of a kernel then Yateto passes nullptr to GemmForge. In this case GemmForge launches a kernel in the default GPU stream.

The type of stream pointer is chosen to be` void*` on purpose because we don't want any GPU specific code to propagate neither through SeisSol nor Yateto. Otherwise, we will have to compile everything with either nvcc or hip-clang compilers which will heavily effect the building system.