### PR TITLE
Add support for AMD Rome

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -122,6 +122,7 @@ def getArchitectureIdentifiedBy(ident):
     'skx': Architecture(name, precision, 64, True),
     'knc': Architecture(name, precision, 64, False),
     'knl': Architecture(name, precision, 64, True), # Libxsmm currently supports prefetch only for KNL kernels
+    'rome': Architecture(name, precision, 32, False),
     'thunderx2t99': Architecture(name, precision, 16, False),
     'power9': Architecture(name, precision, 16, False)
   }

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -254,7 +254,7 @@ class ExecuteGemmGen(RoutineGenerator):
         self._gemmDescr['beta'],
         self._gemmDescr['alignedA'],
         self._gemmDescr['alignedC'],
-        cpu_arch,
+        'hsw' if cpu_arch == 'rome' else cpu_arch,
         self._gemmDescr['prefetch'],
         self._arch.precision + 'P'
       ]

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -254,7 +254,7 @@ class ExecuteGemmGen(RoutineGenerator):
         self._gemmDescr['beta'],
         self._gemmDescr['alignedA'],
         self._gemmDescr['alignedC'],
-        'hsw' if cpu_arch == 'rome' else cpu_arch,
+        'hsw' if cpu_arch == 'rome' else cpu_arch, # libxsmm has no support for rome, hsw works well in practice
         self._gemmDescr['prefetch'],
         self._arch.precision + 'P'
       ]

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -139,7 +139,7 @@ class LIBXSMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl'}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'rome'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -233,11 +233,7 @@ class GeneratorCollection(object):
 class DefaultGeneratorCollection(GeneratorCollection):
   def __init__(self, arch):
     super().__init__([])
-    if arch == 'rome':
-      # Fall back to Haswell backend of libxsmm as no official support for rome
-      libxsmm = LIBXSMM('hsw')
-    else: 
-      libxsmm = LIBXSMM(arch)
+    libxsmm = LIBXSMM(arch)
     pspamm = PSpaMM(arch)
     mkl = MKL(arch)
     blis = BLIS(arch)

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -233,7 +233,11 @@ class GeneratorCollection(object):
 class DefaultGeneratorCollection(GeneratorCollection):
   def __init__(self, arch):
     super().__init__([])
-    libxsmm = LIBXSMM(arch)
+    if arch == 'rome':
+      # Fall back to Haswell backend of libxsmm as no official support for rome
+      libxsmm = LIBXSMM('hsw')
+    else: 
+      libxsmm = LIBXSMM(arch)
     pspamm = PSpaMM(arch)
     mkl = MKL(arch)
     blis = BLIS(arch)
@@ -243,6 +247,7 @@ class DefaultGeneratorCollection(GeneratorCollection):
     defaults = {
       'snb' : [libxsmm, mkl, blis, eigen],
       'hsw' : [libxsmm, mkl, blis, eigen],
+      'rome' : [libxsmm, eigen],
       'knl' : [libxsmm, pspamm, mkl, blis, eigen],
       'skx' : [libxsmm, pspamm, mkl, blis, eigen],
       'thunderx2t99' : [pspamm, openblas, blis, eigen],

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -243,7 +243,7 @@ class DefaultGeneratorCollection(GeneratorCollection):
     defaults = {
       'snb' : [libxsmm, mkl, blis, eigen],
       'hsw' : [libxsmm, mkl, blis, eigen],
-      'rome' : [libxsmm, eigen],
+      'rome' : [libxsmm, blis, eigen],
       'knl' : [libxsmm, pspamm, mkl, blis, eigen],
       'skx' : [libxsmm, pspamm, mkl, blis, eigen],
       'thunderx2t99' : [pspamm, openblas, blis, eigen],


### PR DESCRIPTION
Add support for rome architecture.
SeisSol commit follows afterwards with specific compiler settings.

@uphoffc It's a bit messy to switch to hsw during code generation but the entire thing is very messy... Do you have a better idea?

Definitely squash before merging. First commit was very wrong.