### PR TITLE
Bugfix: Do not assign new buffer if temporary variable is already map…

### DIFF
--- a/yateto/controlflow/transformer.py
+++ b/yateto/controlflow/transformer.py
@@ -124,7 +124,9 @@ class DetermineLocalInitialization(object):
       ua = cfg[i].action
       # assign buffer
       if ua and not ua.isCompound() and ua.result.isLocal():
-        if len(freeBuffers) > 0:
+        if ua.result in usedBuffers:
+            buf = usedBuffers[ua.result]
+        elif len(freeBuffers) > 0:
           buf = freeBuffers.pop()
         else:
           buf = numBuffers


### PR DESCRIPTION
…ped to a buffer

Example:
_tmp7 = A;
...
_tmp7 = 0.5 * _tmp7;

was affected by the bug as the second _tmp7 got mapped to the wrong buffer.