### PR TITLE
prepared the jenkins pipeline for a server

### DIFF
--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -1,12 +1,34 @@
-properties([parameters([string(defaultValue: '', description: 'target architecture (according to yateto format). If not given then taken from Jenkins env-vars', name: 'ARCH', trim: true),
-                        string(defaultValue: 'matmul minimal', description: 'whitespace separate list of examples', name: 'EXAMPLES', trim: true),
-                        string(defaultValue: 'Eigen LIBXSMM OpenBLAS', description: 'whitespace separate list of generators', name: 'GENERATORS', trim: true),
-                        booleanParam(defaultValue: false, description: 'if true the environment image will be build. Note: it will take a considerable amount of time', name: 'BUILD_ENV_IMAGE')
-                        ])])
+properties([
+    parameters([string(
+                    defaultValue: 'runner', 
+                    description: 'agent name which tells where to run a job', 
+                    name: 'AGENT',
+                    trim: true),
+                string(
+                    defaultValue: '', 
+                    description: 'target architecture (according to yateto format). If not given then taken from Jenkins env-vars', 
+                    name: 'ARCH', 
+                    trim: true),
+                string(
+                    defaultValue: 'matmul minimal', 
+                    description: 'whitespace separate list of examples', 
+                    name: 'EXAMPLES', 
+                    trim: true),
+                string(
+                    defaultValue: 'Eigen LIBXSMM OpenBLAS', 
+                    description: 'whitespace separate list of generators', 
+                    name: 'GENERATORS', 
+                    trim: true),
+                booleanParam(
+                    defaultValue: false, 
+                    description: 'if true the environment image will be build. Note: it will take a considerable amount of time', 
+                    name: 'BUILD_ENV_IMAGE')
+    ])
+])
 
 
 pipeline {
-    agent any
+    agent {label "${params.AGENT}"}
 
     stages {
         stage('CleanWorkspace') {
@@ -33,12 +55,18 @@ pipeline {
                 // Make sure that Jenkins knows the location of Spack. 
                 // You will need to add it to the Jenkins settings
                 dir("tests") {
-                    sh 'spack containerize > ./Dockerfile-env'
-                    sh 'cat ./Dockerfile-env'
-
-                    script {
-                        def customImage = docker.build("ravilmobile/yateto-env", "-f Dockerfile-env .")
-                        customImage.push("latest")
+                     script {
+                        withCredentials([usernamePassword(credentialsId: 'docker-hub', 
+                                                      usernameVariable: 'USERNAME', 
+                                                      passwordVariable: 'PASSWORD')]) {
+                            sh """
+                            docker run --rm -v \$(pwd):/home -w /home ${USERNAME}/spack-ubuntu-1804:latest containerize > ./Dockerfile-env
+                            cat ./Dockerfile-env
+                            docker login -u ${USERNAME} -p ${PASSWORD}
+                            """
+                            def customImage = docker.build("${USERNAME}/yateto-env", "-f Dockerfile-env .")
+                            customImage.push("latest")
+                        }
                     }
                 }
             }
@@ -103,19 +131,19 @@ cmake .. && make && make test
                 sh "mkdir ./cache"
                 
                 script {
-                    // define runner arch. for testing
+                    // define test arch. for testing
                     //  if the user specifies ARCH as parameter it is going to be used for testing
                     //  if not, we will try to get ARCH from the Jenkins env. variables 
                     //  if the user didn't set env.HOST_ARCH in his/her Jenkins settings, then 'noarch' will be used
-                    env.RUNNER_ARCH="noarch"
+                    env.TEST_ARCH="noarch"
                     if (!env.ARCH.allWhitespace) {
-                        env.RUNNER_ARCH=env.ARCH
+                        env.TEST_ARCH=env.ARCH
                     }
-                    else if (env.HOST_ARCH) {
-                        env.RUNNER_ARCH=env.HOST_ARCH
+                    else if (env.RUNNER_HOST_ARCH) {
+                        env.TEST_ARCH=env.RUNNER_HOST_ARCH
                     }
                 }
-                sh 'docker container run --rm -e ARCH="${RUNNER_ARCH}" -e EXAMPLES="${EXAMPLES}" -e GENERATORS="${GENERATORS}" -v $(pwd)/cache:/cache -v $(pwd)/run_tests.sh:/local_workspace/tests/run_tests.sh yateto:latest run_tests.sh'
+                sh 'docker container run --rm -e ARCH="${TEST_ARCH}" -e EXAMPLES="${EXAMPLES}" -e GENERATORS="${GENERATORS}" -v $(pwd)/cache:/cache -v $(pwd)/run_tests.sh:/local_workspace/tests/run_tests.sh yateto:latest run_tests.sh'
             }
         }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ in you current working environment.
 | code-gen  |     2 tests     |
 
 
-## Running tests
+## Running tests manually
 ### Interface
 ```console
 cd mkdir interface/build && cd interface/build
@@ -75,3 +75,14 @@ cmake .. -DPRECISION=single -DVARIANT=LIBXSMM
 make
 ctest
 ```
+
+## Running tests automatically
+The following [pipeline](Jenkinsfile) has been implemented to run the aforementioned tests automatically. As a regular user, you can see results of the last few runs of the pipeline [here](http://vmbungartz10.informatik.tu-muenchen.de/seissol/view/Yateto/job/yateto-codegen/). 
+
+You can trigger the pipeline and thus run all tests if you a member of SeisSol in github. To achive this, please, perform the following steps:
+
+- open this [page](http://vmbungartz10.informatik.tu-muenchen.de/seissol/view/Yateto/job/yateto-codegen/)
+- click on `log in` button at the top right corner and follow the authentication procedure
+- click on `Build with Parameters` button. You will be forwarded to the next page where you can adjust parameters. We do not recommend to make any changes in `AGENT` and `BUILD_ENV_IMAGE` fields
+- click on `Build` to trigger the pipeline. 
+- After that, you will see a new flashing entry at the very top of `Build History` field. If you want to see a detail status information about all steps involved in the pipeline then click on a dropdown widget of the flashing entry and select `Console Output`

--- a/tests/spack.yaml
+++ b/tests/spack.yaml
@@ -2,19 +2,21 @@ spack:
   specs:
   - eigen@3.3.7
   - openblas@0.3.9
-  - libxsmm+generator
+  - libxsmm+generator@1.15
   - cmake@3.16.0
 
   container:
     format: docker
 
-    base:
-      image: "ubuntu:18.04"
-      spack: develop
+    images:
+      build: ravilmobile/spack-ubuntu-1804:latest
+      final: ubuntu:18.04
 
     strip: true
 
     os_packages:
+      command: apt
+      final:
       - python3
       - python3-pip
       - make


### PR DESCRIPTION
The pipeline was a little bit improved and deployed on TUM SCCS Jenkins server. All SeisSol developers can go there and manually trigger the pipeline by clicking on `Build with Parameters` and then `Build`. Please, write me a PM to SeisSol Slack If you cannot remember Jenkins server URL.

We can also set up a webhooks to trigger the pipeline automatically.

Planned future improvements:
- add more tests for codegen, [for example](https://github.com/SeisSol/yateto/blob/master/examples/seissol_eqspp.py)
- create a dedicated runner for yateto and use OpenStack REST API for shelving/unshelving the runner