### PR TITLE
Updated reference to gemmforge (to version 0.0.203)

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -47,7 +47,6 @@ class Architecture(object):
                enablePrefetch=False,
                sub_name=None,
                host_name=None):
-  #def __init__(self, name, sub_name, precision, alignment, enablePrefetch=False, host_name=None):
     """
 
     Args:
@@ -75,7 +74,7 @@ class Architecture(object):
       self.typename = 'float'
       self.epsilon = 1.19e-7
     else:
-      raise ValueError('Unknown precision type ' + self.precision)
+      raise ValueError(f'Unknown precision type {self.precision}')
     self.alignment = alignment
     assert self.alignment % self.bytesPerReal == 0
     self.alignedReals = self.alignment // self.bytesPerReal

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -91,7 +91,7 @@ class BatchedOperationsAux:
   NUM_ELEMENTS_NAME = 'numElements'
   EXTRA_OFFSET_NAME = 'extraOffset'
   STREAM_PTR_NAME = 'streamPtr'
-  FORBIDDEN_STREAM = 'reinterpret_cast<void*>(0xffffffffffffffff)'
+  FORBIDDEN_STREAM_PTR = 'reinterpret_cast<void*>(std::numeric_limits<uintptr_t>::max())'
 
   def __init__(self, underlying_data_type):
     self.underlying_data_type = underlying_data_type

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -91,6 +91,7 @@ class BatchedOperationsAux:
   NUM_ELEMENTS_NAME = 'numElements'
   EXTRA_OFFSET_NAME = 'extraOffset'
   STREAM_PTR_NAME = 'streamPtr'
+  FORBIDDEN_STREAM = 'reinterpret_cast<void*>(0xffffffffffffffff)'
 
   def __init__(self, underlying_data_type):
     self.underlying_data_type = underlying_data_type

--- a/yateto/codegen/copyscaleadd/csa_gen.py
+++ b/yateto/codegen/copyscaleadd/csa_gen.py
@@ -84,9 +84,9 @@ class CopyScaleAddGenerator(object):
                                                          transpose=False)
 
       try:
-        forge_generator = gf.CsaGenerator(gf.arch.produce(self._arch.name, self._arch.sub_name),
-                                       self._arch.typename)
-        forge_generator.generate(matrix_a, matrix_b, alpha, d.beta)
+        vm = gf.vm_factory(self._arch.name, self._arch.sub_name, fp_type=self._arch.typename)
+        forge_generator = gf.CsaGenerator(vm)
+        forge_generator.set(matrix_a, matrix_b, alpha, d.beta)
         routine_name = forge_generator.get_base_name()
 
         args = [str(alpha),
@@ -111,10 +111,8 @@ class CopyScaleAddGenerator(object):
 
 class GemmForgeWriter(GpuRoutineGenerator):
   def __init__(self, forge_generator):
+    self._generator = forge_generator
     self._basename = forge_generator.get_base_name()
-    self._declaration = forge_generator.get_launcher_header()
-    self._launcher = forge_generator.get_launcher()
-    self._kernel = forge_generator.get_kernel()
 
   def __eq__(self, other):
     if isinstance(other, GemmForgeWriter):
@@ -123,11 +121,16 @@ class GemmForgeWriter(GpuRoutineGenerator):
       return False
 
   def header(self, cpp):
-    cpp.include('gemmgen_aux.h')
+    cpp.include('gemmforge_aux.h')
 
   def __call__(self, routineName, fileName):
-    with open(fileName, "a") as file:
-      file.write(self._kernel)
-      file.write(self._launcher)
+    self._generator.generate()
+    declaration = self._generator.get_launcher_header()
+    launcher = self._generator.get_launcher()
+    kernel = self._generator.get_kernel()
 
-    return self._declaration
+    with open(fileName, "a") as file:
+      file.write(kernel)
+      file.write(launcher)
+
+    return declaration

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -72,7 +72,7 @@ class KernelFactory(object):
     if self._target == 'cpu':
       pass
     elif self._target == 'gpu':
-      self._cpp(f'{BatchedOperationsAux.STREAM_PTR_NAME} = nullptr;')
+      self._cpp(f'{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM};')
     else:
       raise RuntimeError('unknown compute target')
 

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -72,7 +72,7 @@ class KernelFactory(object):
     if self._target == 'cpu':
       pass
     elif self._target == 'gpu':
-      self._cpp(f'{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM};')
+      self._cpp(f'{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM_PTR};')
     else:
       raise RuntimeError('unknown compute target')
 

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -295,7 +295,7 @@ class OptimisedKernelGenerator(KernelGenerator):
         # containers with extra offsets for GPU-like computations
         if target == 'gpu':
           header(f'unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME} = 0;')
-          header(f'void *{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM};')
+          header(f'void *{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM_PTR};')
 
           def generate_extra_offset_args(base_name_with_namespace, groups):
             prefix, base_name = Tensor.splitBasename(base_name_with_namespace)
@@ -380,7 +380,7 @@ class OptimisedKernelGenerator(KernelGenerator):
 
         if target == 'gpu':
           cpp(f'assert({BatchedOperationsAux.NUM_ELEMENTS_NAME} != 0);')
-          cpp(f'assert({BatchedOperationsAux.STREAM_PTR_NAME} != {BatchedOperationsAux.FORBIDDEN_STREAM});')
+          cpp(f'assert({BatchedOperationsAux.STREAM_PTR_NAME} != {BatchedOperationsAux.FORBIDDEN_STREAM_PTR});')
 
         cpp(kernelOutline.function)
 

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -295,7 +295,7 @@ class OptimisedKernelGenerator(KernelGenerator):
         # containers with extra offsets for GPU-like computations
         if target == 'gpu':
           header(f'unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME} = 0;')
-          header(f'void *{BatchedOperationsAux.STREAM_PTR_NAME} = nullptr;')
+          header(f'void *{BatchedOperationsAux.STREAM_PTR_NAME} = {BatchedOperationsAux.FORBIDDEN_STREAM};')
 
           def generate_extra_offset_args(base_name_with_namespace, groups):
             prefix, base_name = Tensor.splitBasename(base_name_with_namespace)
@@ -380,6 +380,7 @@ class OptimisedKernelGenerator(KernelGenerator):
 
         if target == 'gpu':
           cpp(f'assert({BatchedOperationsAux.NUM_ELEMENTS_NAME} != 0);')
+          cpp(f'assert({BatchedOperationsAux.STREAM_PTR_NAME} != {BatchedOperationsAux.FORBIDDEN_STREAM});')
 
         cpp(kernelOutline.function)
 

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -193,7 +193,7 @@ class PSpaMM(CodeGenerator):
 
 class GemmForge(CodeGenerator):
   def __init__(self, arch, threshold: int = 256):
-    super().__init__('', ['gemmgen_aux.h'], '', arch)
+    super().__init__('', ['gemmforge_aux.h'], '', arch)
     self._threshold = threshold
 
   def _is_arch_supported(self):

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -17,6 +17,9 @@ from .controlflow.transformer import *
 from .gemm_configuration import GeneratorCollection, DefaultGeneratorCollection, BLASlike
 from typing import List
 from io import StringIO
+import importlib.util
+chainforge_spec = importlib.util.find_spec('chainforge')
+
 
 class Kernel(object):
   BASE_NAME = r'[a-zA-Z]\w*'
@@ -100,7 +103,7 @@ class Kernel(object):
     self.cfg = SubstituteBackward().visit(self.cfg)
     self.cfg = RemoveEmptyStatements().visit(self.cfg)
     self.cfg = MergeActions().visit(self.cfg)
-    if self.target == 'gpu':
+    if self.target == 'gpu' and chainforge_spec:
       self.cfg = FindFusedGemms().visit(self.cfg)
       self.cfg = LivenessAnalysis().visit(self.cfg)
 

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -334,6 +334,7 @@ class Generator(object):
       cpp.includeSys('cassert')
       cpp.includeSys('cstring')
       cpp.includeSys('cstdlib')
+      cpp.includeSys('limits')
 
       cpp.include(fRoutines.hName)
       with Cpp(fKernels.h) as header:


### PR DESCRIPTION
* gemmforge changed its interface after refactoring
* improved yateto caching of kernel generated by gemmforge
* forced useris **always** initialize streams for batch computing
(no default option anymore). `nullptr` is used by CUDA and HIP as a
default stream. Therefore, a value `0xffffffff` is used instead.
This is necessary because SYCL model uses objects of Queue class
to launch kernels. Queues have a similar meaning as streams
in CUDA/HIP but also has some information about a selected device,
memory, etc.

[Link](http://vmbungartz10.informatik.tu-muenchen.de/seissol/view/Yateto/job/yateto-codegen/10/console) to the test results