### PR TITLE
Fix CI by adding definition

### DIFF
--- a/yateto/codegen/test_framework.py
+++ b/yateto/codegen/test_framework.py
@@ -27,6 +27,10 @@ class TestFramework(ABC):
         cpp.include(kernelsInclude)
         cpp.include(initInclude)
         cpp.include('yateto.h')
+        with cpp.PPIfndef('NDEBUG'):
+            with cpp.PPIfndef('YATETO_TESTING_NO_FLOP_COUNTER'):
+                cpp('long long libxsmm_num_total_flops = 0;')
+                cpp('long long pspamm_num_total_flops = 0;')
 
 class CxxTest(TestFramework):
     TEST_CLASS = 'KernelTestSuite'


### PR DESCRIPTION
The overall change is needed to avoid multiple variables in the SeisSol unit testing build. Slightly hacky, but works.

Sorry for breaking master, branch protection rules are now correctly applied - I thought I was on a different branch.