### PR TITLE
Fixed bugs in FusedGemmsBoundingBoxCostEstimator

### DIFF
--- a/yateto/ast/opt.py
+++ b/yateto/ast/opt.py
@@ -1,5 +1,7 @@
 import sys
 from .node import IndexSum, Product
+from copy import deepcopy
+
 
 def strengthReduction(terms, target_indices, cost_estimator, split = 0):
   n = len(terms)
@@ -29,12 +31,19 @@ def strengthReduction(terms, target_indices, cost_estimator, split = 0):
   for i in range(n):
     for j in range(max(i+1,split),n):
       mulTerm = Product(terms[i], terms[j])
-      prodCost = cost_estimator.estimate(mulTerm)
+      prodCost = deepcopy(cost_estimator).estimate(mulTerm)
       if best == None or prodCost < minCost:
         selection = set(range(n)) - set([i,j])
-        tree = strengthReduction([terms[i] for i in selection] + [mulTerm], target_indices, cost_estimator, j-1)
-        treeCost = cost_estimator.estimate(tree)
+        tree = strengthReduction([terms[i] for i in selection] + [mulTerm],
+                                 deepcopy(target_indices),
+                                 cost_estimator,
+                                 j-1)
+
+        cost_estimator_copy = deepcopy(cost_estimator)
+        treeCost = cost_estimator_copy.estimate(tree)
         if best == None or treeCost < minCost:
           best = tree
           minCost = treeCost
+          cost_estimator = cost_estimator_copy
+
   return best


### PR DESCRIPTION
This PR contains some fixes for both strength reduction and `FusedGemmsBoundingBoxCostEstimator`.

* added `deepcopy` to the strength reduction because an estimator (e.g., `FusedGemmsBoundingBoxCostEstimator`) can contain some data members  which can keep a state between invocations. Any estimator is going to be applied to non optimal sub-trees before the algorithm comes to an optimal solution. It happens because of the `exhaustive` nature of the algorithm. Therefore, `deepcopy` allows us to apply an estimator to any sub-stree with an opportunity to  restore its previous state.