### PR TITLE
Fix zero dimensional tensor

### DIFF
--- a/include/yateto/TensorView.h
+++ b/include/yateto/TensorView.h
@@ -49,6 +49,22 @@ namespace yateto {
     uint_t m_shape[Dim];
   };
 
+  template<typename real_t, typename uint_t>
+  class TensorView<0, real_t, uint_t> {
+  public:
+    explicit TensorView(std::initializer_list<uint_t> shape) {} 
+
+    explicit TensorView(uint_t const shape[]) {}
+    
+    constexpr uint_t dim() const {
+      return 0;
+    }
+
+    uint_t shape(uint_t dim) const {
+      return 0;
+    }
+  };
+
   template<unsigned Dim, typename real_t, typename uint_t=unsigned>
   class DenseTensorView : public TensorView<Dim, real_t, uint_t> {
   public:


### PR DESCRIPTION
In https://github.com/SeisSol/SeisSol/commit/0d6742a64b3497c0458c60b7d21d037292fb1d33, we introduced a zero dimensional tensor, mostly as a workaround since `Scalar = Scalar + einsum` does not work.
The zero dimensional tensor introduced a lot of ` warning: ISO C++ forbids zero-size array [-Wpedantic]` in SeisSol. 
This partial template specialization fixes the issue. @Thomas-Ulrich @krenzland please check, if the energy output still produces correct output.