### PR TITLE
Make YATeTo installable via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -17,7 +17,7 @@ setup(
     description="A tensor toolbox for discontinuous Galerkin methods",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=["yateto"],
+    packages=find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD 3-Clause License",


### PR DESCRIPTION
Right now, YATeTo only imported the top-level module for pip, and thus did not run. This PR fixes that.