### PR TITLE
Make YATeTo fail on GEMM gen failure

### DIFF
--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -221,10 +221,13 @@ class ExecuteGemmGen(RoutineGenerator):
       cpp.includeSys('immintrin.h')
 
   def _callGenerator(self, argList):
+    resultCode = 1
     try:
-      subprocess.call([str(arg) for arg in argList])
+      resultCode = subprocess.call([str(arg) for arg in argList])
     except OSError:
       raise RuntimeError('GEMM code generator executable "{}" not found. (Make sure to add the folder containing the executable to your PATH.)'.format(self._cmd))
+    if resultCode != 0:
+      raise RuntimeError('GEMM code generator executable "{}" failed. Thus, the kernel generation may be incomplete.'.format(self._cmd))
   
   def __call__(self, routineName, fileName):
     cpu_arch = self._arch.host_name if self._arch.host_name else self._arch.name


### PR DESCRIPTION
As the title says. The idea was discussed in [#841](https://github.com/SeisSol/SeisSol/issues/841).