### PR TITLE
Add PspaMM support for Rome and HSW

### DIFF
--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -233,6 +233,13 @@ class ExecuteGemmGen(RoutineGenerator):
     cpu_arch = self._arch.host_name if self._arch.host_name else self._arch.name
 
     if self._mode == 'pspamm':
+      pspamm_arch = cpu_arch
+      if cpu_arch == 'a64fx':
+        pspamm_arch = 'arm_sve'
+      elif cpu_arch in ['naples', 'rome', 'milan']:
+        # names are Zen1, Zen2, Zen3, respectively
+        # no explicit support for these archs yet, but they have the same instruction sets (AVX2+FMA3) that HSW also needs
+        pspamm_arch = 'hsw'
       argList = [
         self._cmd,
         self._gemmDescr['M'],
@@ -244,7 +251,7 @@ class ExecuteGemmGen(RoutineGenerator):
         self._gemmDescr['alpha'],
         self._gemmDescr['beta'],
         '--arch',
-        'arm_sve' if cpu_arch == 'a64fx' else cpu_arch, 
+        pspamm_arch, 
         '--prefetching',
         self._gemmDescr['prefetch'],
         '--output_funcname',


### PR DESCRIPTION
Also adds the names `naples` (Zen1/server) and `milan` (Zen3/server), since they also only have AVX2+FMA3.