### PR TITLE
Add Some More CPU Architectures

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -117,26 +117,27 @@ def getArchitectureIdentifiedBy(ident):
 
   # NOTE: ibxsmm currently supports prefetch only for KNL kernels
   arch = {
-    'noarch': Architecture(name, precision, 16, False),
-    'wsm': Architecture(name, precision, 16, False),
-    'snb': Architecture(name, precision, 32, False),
-    'hsw': Architecture(name, precision, 32, False),
+    'noarch': Architecture(name, precision, 64, False),
+    'wsm': Architecture(name, precision, 64, False),
+    'snb': Architecture(name, precision, 64, False),
+    'hsw': Architecture(name, precision, 64, False),
     'skx': Architecture(name, precision, 64, True),
     'knc': Architecture(name, precision, 64, False),
     'knl': Architecture(name, precision, 64, True),
-    'naples': Architecture(name, precision, 32, False),
-    'rome': Architecture(name, precision, 32, False),
-    'milan': Architecture(name, precision, 32, False),
+    'naples': Architecture(name, precision, 64, False),
+    'rome': Architecture(name, precision, 64, False),
+    'milan': Architecture(name, precision, 64, False),
     'bergamo': Architecture(name, precision, 64, False),
-    'thunderx2t99': Architecture(name, precision, 16, False),
+    'thunderx2t99': Architecture(name, precision, 64, False),
     'a64fx': Architecture(name, precision, 256, True),
-    'neon': Architecture(name, precision, 16, False),
-    'sve128': Architecture(name, precision, 16, False),
-    'sve256': Architecture(name, precision, 32, False),
+    'neon': Architecture(name, precision, 64, False),
+    'apple-m1': Architecture(name, precision, 128, False),
+    'sve128': Architecture(name, precision, 64, False),
+    'sve256': Architecture(name, precision, 64, False),
     'sve512': Architecture(name, precision, 64, False),
     'sve1024': Architecture(name, precision, 128, False),
     'sve2048': Architecture(name, precision, 256, False),
-    'power9': Architecture(name, precision, 16, False)
+    'power9': Architecture(name, precision, 64, False)
   }
   return arch[name]
 

--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -137,7 +137,6 @@ def getArchitectureIdentifiedBy(ident):
     'sve512': Architecture(name, precision, 64, False),
     'sve1024': Architecture(name, precision, 128, False),
     'sve2048': Architecture(name, precision, 256, False),
-    'apple-m1': Architecture(name, precision, 16, False),
     'power9': Architecture(name, precision, 16, False),
   }
   return arch[name]

--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -115,29 +115,30 @@ def _get_name_and_precision(ident):
 def getArchitectureIdentifiedBy(ident):
   name, precision = _get_name_and_precision(ident)
 
-  # NOTE: ibxsmm currently supports prefetch only for KNL kernels
+  # NOTE: libxsmm currently supports prefetch only for KNL kernels
   arch = {
-    'noarch': Architecture(name, precision, 64, False),
-    'wsm': Architecture(name, precision, 64, False),
-    'snb': Architecture(name, precision, 64, False),
-    'hsw': Architecture(name, precision, 64, False),
+    'noarch': Architecture(name, precision, 16, False),
+    'wsm': Architecture(name, precision, 16, False),
+    'snb': Architecture(name, precision, 32, False),
+    'hsw': Architecture(name, precision, 32, False),
     'skx': Architecture(name, precision, 64, True),
     'knc': Architecture(name, precision, 64, False),
     'knl': Architecture(name, precision, 64, True),
-    'naples': Architecture(name, precision, 64, False),
-    'rome': Architecture(name, precision, 64, False),
-    'milan': Architecture(name, precision, 64, False),
-    'bergamo': Architecture(name, precision, 64, False),
-    'thunderx2t99': Architecture(name, precision, 64, False),
-    'a64fx': Architecture(name, precision, 256, True),
-    'neon': Architecture(name, precision, 64, False),
-    'apple-m1': Architecture(name, precision, 128, False),
-    'sve128': Architecture(name, precision, 64, False),
-    'sve256': Architecture(name, precision, 64, False),
+    'naples': Architecture(name, precision, 32, False),
+    'rome': Architecture(name, precision, 32, False),
+    'milan': Architecture(name, precision, 32, False),
+    'bergamo': Architecture(name, precision, 64, True),
+    'thunderx2t99': Architecture(name, precision, 16, False),
+    'a64fx': Architecture(name, precision, 64, True),
+    'neon': Architecture(name, precision, 16, False),
+    'apple-m1': Architecture(name, precision, 16, False),
+    'sve128': Architecture(name, precision, 16, False),
+    'sve256': Architecture(name, precision, 32, False),
     'sve512': Architecture(name, precision, 64, False),
     'sve1024': Architecture(name, precision, 128, False),
     'sve2048': Architecture(name, precision, 256, False),
-    'power9': Architecture(name, precision, 64, False)
+    'apple-m1': Architecture(name, precision, 16, False),
+    'power9': Architecture(name, precision, 16, False),
   }
   return arch[name]
 

--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -124,9 +124,18 @@ def getArchitectureIdentifiedBy(ident):
     'skx': Architecture(name, precision, 64, True),
     'knc': Architecture(name, precision, 64, False),
     'knl': Architecture(name, precision, 64, True),
+    'naples': Architecture(name, precision, 32, False),
     'rome': Architecture(name, precision, 32, False),
+    'milan': Architecture(name, precision, 32, False),
+    'bergamo': Architecture(name, precision, 64, False),
     'thunderx2t99': Architecture(name, precision, 16, False),
     'a64fx': Architecture(name, precision, 256, True),
+    'neon': Architecture(name, precision, 16, False),
+    'sve128': Architecture(name, precision, 16, False),
+    'sve256': Architecture(name, precision, 32, False),
+    'sve512': Architecture(name, precision, 64, False),
+    'sve1024': Architecture(name, precision, 128, False),
+    'sve2048': Architecture(name, precision, 256, False),
     'power9': Architecture(name, precision, 16, False)
   }
   return arch[name]

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -240,8 +240,8 @@ Stderr: {result.stderr}""")
       pspamm_arch = cpu_arch
       if cpu_arch == 'a64fx':
         pspamm_arch = 'arm_sve512'
-      elif cpu_arch == 'thunderx2t99':
-        pspamm_arch = 'neon'
+      elif cpu_arch in ['apple-m1', 'thunderx2t99', 'neon']:
+        pspamm_arch = 'arm'
       elif cpu_arch.startswith('sve'):
         pspamm_arch = f'arm_{cpu_arch}' # TODO(David): rename to sveLEN only
       elif cpu_arch in ['naples', 'rome', 'milan']:

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -239,11 +239,17 @@ Stderr: {result.stderr}""")
     if self._mode == 'pspamm':
       pspamm_arch = cpu_arch
       if cpu_arch == 'a64fx':
-        pspamm_arch = 'arm_sve'
+        pspamm_arch = 'arm_sve512'
+      elif cpu_arch == 'thunderx2t99':
+        pspamm_arch = 'neon'
+      elif cpu_arch.startswith('sve'):
+        pspamm_arch = f'arm_{cpu_arch}' # TODO(David): rename to sveLEN only
       elif cpu_arch in ['naples', 'rome', 'milan']:
         # names are Zen1, Zen2, Zen3, respectively
         # no explicit support for these archs yet, but they have the same instruction sets (AVX2+FMA3) that HSW also needs
         pspamm_arch = 'hsw'
+      elif cpu_arch in ['bergamo']:
+        pspamm_arch = 'skx'
       argList = [
         self._cmd,
         self._gemmDescr['M'],
@@ -268,6 +274,13 @@ Stderr: {result.stderr}""")
       for key, val in self._blockSize.items():
         argList.extend(['--' + key, val])
     else:
+      libxsmm_arch = cpu_arch
+      if cpu_arch in ['naples', 'rome', 'milan']:
+        # names are Zen1, Zen2, Zen3, respectively
+        # no explicit support for these archs yet, but they have the same instruction sets (AVX2+FMA3) that HSW also needs
+        libxsmm_arch = 'hsw'
+      elif cpu_arch in ['bergamo']:
+        libxsmm_arch = 'skx'
       argList = [
         self._cmd,
         'dense',
@@ -283,7 +296,7 @@ Stderr: {result.stderr}""")
         self._gemmDescr['beta'],
         self._gemmDescr['alignedA'],
         self._gemmDescr['alignedC'],
-        'hsw' if cpu_arch == 'rome' else cpu_arch, # libxsmm has no support for rome, hsw works well in practice
+        libxsmm_arch, # libxsmm has no support for rome, hsw works well in practice
         self._gemmDescr['prefetch'],
         self._arch.precision + 'P'
       ]

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -162,7 +162,7 @@ class LIBXSMM_JIT(CodeGenerator):
     return Preference.LOW
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'rome', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512'}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -286,7 +286,7 @@ class DefaultGeneratorCollection(GeneratorCollection):
   def __init__(self, arch):
     super().__init__([])
     libxsmm = LIBXSMM(arch)
-    # libxsmm_jit = LIBXSMM_JIT(arch)
+    libxsmm_jit = LIBXSMM_JIT(arch)
     pspamm = PSpaMM(arch)
     mkl = MKL(arch)
     blis = BLIS(arch)

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -162,7 +162,7 @@ class LIBXSMM_JIT(CodeGenerator):
     return Preference.LOW
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'rome', "a64fx", "thunderx2t99"}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'rome', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -184,7 +184,7 @@ class LIBXSMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'rome'}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -210,7 +210,7 @@ class PSpaMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'thunderx2t99', 'knl', 'skx', 'a64fx'}
+    supported_set = {'thunderx2t99', 'knl', 'skx', 'a64fx', 'hsw', 'naples', 'rome', 'milan', 'bergamo', 'neon', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048'}
     if self._arch.name.lower() in supported_set:
       return True
     else:
@@ -286,7 +286,7 @@ class DefaultGeneratorCollection(GeneratorCollection):
   def __init__(self, arch):
     super().__init__([])
     libxsmm = LIBXSMM(arch)
-    libxsmm_jit = LIBXSMM_JIT(arch)
+    # libxsmm_jit = LIBXSMM_JIT(arch)
     pspamm = PSpaMM(arch)
     mkl = MKL(arch)
     blis = BLIS(arch)
@@ -295,12 +295,21 @@ class DefaultGeneratorCollection(GeneratorCollection):
     forge = GemmForge(arch)
     defaults = {
       'snb' : [libxsmm_jit, libxsmm, mkl, blis, eigen],
-      'hsw' : [libxsmm_jit, libxsmm, mkl, blis, eigen],
-      'rome' : [libxsmm_jit, libxsmm, blis, eigen],
+      'hsw' : [libxsmm_jit, libxsmm, pspamm, mkl, blis, eigen],
+      'naples' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
+      'rome' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
+      'milan' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
+      'bergamo' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
       'knl' : [libxsmm_jit, libxsmm, pspamm, mkl, blis, eigen],
       'skx' : [libxsmm_jit, libxsmm, pspamm, mkl, blis, eigen],
       'thunderx2t99' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'a64fx' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'neon' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'sve128' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'sve256' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'sve512' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'sve1024' : [pspamm, openblas, blis, eigen],
+      'sve2048' : [pspamm, openblas, blis, eigen],
       'power9' : [openblas, blis, eigen]
     }
 

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -162,7 +162,7 @@ class LIBXSMM_JIT(CodeGenerator):
     return Preference.LOW
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512'}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512', 'apple-m1'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -210,7 +210,7 @@ class PSpaMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'thunderx2t99', 'knl', 'skx', 'a64fx', 'hsw', 'naples', 'rome', 'milan', 'bergamo', 'neon', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048'}
+    supported_set = {'thunderx2t99', 'knl', 'skx', 'a64fx', 'hsw', 'naples', 'rome', 'milan', 'bergamo', 'neon', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048', 'apple-m1'}
     if self._arch.name.lower() in supported_set:
       return True
     else:


### PR DESCRIPTION
Dependent on https://github.com/SeisSol/PSpaMM/pull/7 .

As the title says, we merely add the CPU archs. Most notably Zen4 ("bergamo", although there is also another code name... Maybe we should just go with Zen1 to 4 one day), and SVE128, 256, (512), 1024, 2048.

Draft for now.