### PR TITLE
Two Bugfixes: Non-Const Copy-Scale-Add Inputs and Debug Builds

### DIFF
--- a/yateto/codegen/copyscaleadd/csa_gen.py
+++ b/yateto/codegen/copyscaleadd/csa_gen.py
@@ -90,7 +90,7 @@ class CopyScaleAddGenerator(object):
         routine_name = forge_generator.get_base_name()
 
         args = [str(alpha),
-                aux.deduce_arg(d.term),
+                aux.deduce_arg(d.term, as_const=True),
                 aux.deduce_arg(d.result),
                 BatchedOperationsAux.NUM_ELEMENTS_NAME,
                 BatchedOperationsAux.FLAGS_NAME,

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -381,9 +381,13 @@ class OptimisedKernelGenerator(KernelGenerator):
         continue
 
       with cpp.Function('{}::{}::{}'.format(self.NAMESPACE, name, executeName(index))):
-        sclrs = sorted(list(kernelOutline.scalars), key=str)
-        for scalar in sclrs:
-          cpp('assert(!std::isnan({}));'.format(scalar))
+        for base_name_with_namespace, groups in kernelOutline.scalars:
+          base_name = Tensor.splitBasename(base_name_with_namespace)[-1]
+          if len(next(iter(groups))) > 0:
+            for gis in groups:
+              cpp('assert(!std::isnan({}({})));'.format(base_name, ','.join(str(gi) for gi in gis)))
+          else:
+            cpp(f'assert(!std::isnan({base_name}));')
         for base_name_with_namespace, groups in kernelOutline.tensors.items():
           base_name = Tensor.splitBasename(base_name_with_namespace)[-1]
           if len(next(iter(groups))) > 0:

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -381,7 +381,7 @@ class OptimisedKernelGenerator(KernelGenerator):
         continue
 
       with cpp.Function('{}::{}::{}'.format(self.NAMESPACE, name, executeName(index))):
-        for base_name_with_namespace, groups in kernelOutline.scalars:
+        for base_name_with_namespace, groups in kernelOutline.scalars.items():
           base_name = Tensor.splitBasename(base_name_with_namespace)[-1]
           if len(next(iter(groups))) > 0:
             for gis in groups:


### PR DESCRIPTION
We handle two bugfixes:

* Re-enable debug builds (the assertions were broken for scalar families, introduced in #54 )
* Allow non-const copy-scale-add input.

Needed especially for https://github.com/SeisSol/SeisSol/pull/928 .