### PR TITLE
Update Tiny Tensor Compiler integration

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -155,7 +155,7 @@ def getHeterogeneousArchitectureIdentifiedBy(host_arch, device_arch, device_back
     alignment = 64
   elif 'gfx' in device_arch: 
     alignment = 128
-  elif device_arch in ['dg1', 'bdw', 'skl', 'Gen8', 'Gen9', 'Gen11', 'Gen12LP']:
+  elif device_arch in ['dg1', 'bdw', 'skl', 'Gen8', 'Gen9', 'Gen11', 'Gen12LP', 'pvc']:
     alignment = 32
   else:
     raise ValueError(f'Unknown device arch: {device_arch}')

--- a/yateto/codegen/cache.py
+++ b/yateto/codegen/cache.py
@@ -38,3 +38,24 @@ class RoutineCache(object):
       else:
         declaration = generator(name, cppFileName)
       header(declaration)
+
+class TinytcWriter(GpuRoutineGenerator):
+  def __init__(self, signature, source):
+    self._source = source
+    self._signature = signature
+
+  def __eq__(self, other):
+    return self._signature == other._signature
+
+  def header(self, cpp):
+    cpp.include('tinytc/tinytc.hpp')
+    cpp.include('tinytc/tinytc_sycl.hpp')
+    cpp.includeSys('sycl/sycl.hpp')
+    cpp.includeSys('stdexcept')
+    cpp.includeSys('utility')
+
+  def __call__(self, routineName, fileName):
+    with open(fileName, 'a') as f:
+      f.write(self._source)
+
+    return self._signature

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -166,7 +166,7 @@ class TinytcWrapper:
     hasher.update(self.source.encode('utf-8'))
     self.name = f'tinytc_wrapper_{hasher.hexdigest()}'
     
-    self.wrapper_args = [f'unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME}', f'void* {BatchedOperationsAux.STREAM_PTR_NAME}']
+    self.wrapper_args = [f'long {BatchedOperationsAux.NUM_ELEMENTS_NAME}', f'void* {BatchedOperationsAux.STREAM_PTR_NAME}']
     self.wrapper_call_args = []
     self.call_args = []
     for arg in arguments:
@@ -185,7 +185,7 @@ class TinytcWrapper:
             self.wrapper_call_args.append(BatchedOperationsAux.NUM_ELEMENTS_NAME)
           elif not arg.constant:
             offset_name = f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{arg.name}' 
-            self.wrapper_args.append(f'int {offset_name}')
+            self.wrapper_args.append(f'long {offset_name}')
             self.wrapper_call_args.append(offset_name)
             self.call_args.append(f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{arg.call_expr}')
 

--- a/yateto/codegen/copyscaleadd/tinytc.py
+++ b/yateto/codegen/copyscaleadd/tinytc.py
@@ -127,7 +127,7 @@ class CopyScaleAddTinytc:
         ]
         wrapper = TinytcWrapper(kernel, args, self._arch.typename)
 
-        prototype = f'{wrapper.prototype()}'
+        prototype = wrapper.prototype()
         routineCache.addRoutine(prototype,
                                 TinytcWriter(prototype, wrapper.definition()))
 

--- a/yateto/codegen/copyscaleadd/tinytc.py
+++ b/yateto/codegen/copyscaleadd/tinytc.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+from ..common import TensorDescription, IndexedTensorDescription, BatchedOperationsAux, TinytcKernelArgument, TinytcScalarKernelArgument, TinytcWrapper
+from ..cache import TinytcWriter
+from ..tiny_tensor_language import *
+
+
+class CopyScaleAddTinytc:
+
+    def __init__(self, arch, descr):
+        self._arch = arch
+        self._descr = descr
+        self._scalar_type = 'f64' if self._arch.bytesPerReal == 8 else 'f32'
+        self._ty = ScalarType(
+            FloatingType.f64) if self._arch.bytesPerReal == 8 else ScalarType(
+                FloatingType.f32)
+
+    def generate(self, cpp, routineCache):
+        d = self._descr
+
+        def MakeMemrefType(ml, needsBatchMode):
+            shape = tuple(r.size() for r in ml.bbox())
+            stride = ml.stride()
+            if needsBatchMode:
+                shape = shape + (DYNAMIC, )
+                stride = stride + (ml.requiredReals(), )
+            return MemrefType(self._ty, shape, stride)
+
+        def MakeBatchType(var):
+            ml = var.memoryLayout
+            if var.is_compute_constant:
+                return MakeMemrefType(ml, False)
+            elif var.is_temporary:
+                return MakeMemrefType(ml, True)
+            else:
+                return GroupType(MakeMemrefType(ml, False), DYNAMIC)
+
+        def MakeLoad(bb, var, operand, gid):
+            if var.is_compute_constant:
+                return operand
+            elif var.is_temporary:
+                offset_list = [IntImmValue(IntegerType.index, 0)
+                               ] * (operand.type().order() - 1)
+                size_list = [IntImmValue(IntegerType.index, DYNAMIC)
+                             ] * (operand.type().order() - 1)
+                offset_list.append(gid)
+                size_list.append(None)
+                return bb.add(SubviewInst(operand, offset_list, size_list))
+            else:
+                return bb.add(LoadInst(operand, [gid]))
+
+        # Order can be 1 or 2
+        def MakeLoopOverAxpby(d, order, transpose, A, B):
+            beta = FloatImmValue(self._ty, d.beta)
+            A_offset_list = [None] * len(d.term.indices)
+            A_size_list = [None] * len(d.term.indices)
+            B_offset_list = [None] * len(d.result.indices)
+            B_size_list = [None] * len(d.result.indices)
+
+            for j in range(0, order):
+                idx = d.result.indices[j]
+                j_perm = d.term.indices.find(d.result.indices[j])
+                offset = IntImmValue(IntegerType.index,
+                                     d.loopRanges[idx].start)
+                size = IntImmValue(
+                    IntegerType.index,
+                    d.loopRanges[idx].stop - d.loopRanges[idx].start)
+                A_offset_list[j_perm] = offset
+                A_size_list[j_perm] = size
+                B_offset_list[j] = offset
+                B_size_list[j] = size
+
+            for j in range(order, len(d.result.indices)):
+                loop_var = LocalValue(ScalarType(IntegerType.index))
+                j_perm = d.term.indices.find(d.result.indices[j])
+                A_offset_list[j_perm] = loop_var
+                B_offset_list[j] = loop_var
+
+            csa_bb = RegionBuilder()
+            a = csa_bb.add(SubviewInst(A, A_offset_list, A_size_list))
+            b = csa_bb.add(SubviewInst(B, B_offset_list, B_size_list))
+            csa_bb.add(AxpbyInst(trans, alpha, a, beta, b))
+            csa_region = csa_bb.get_product()
+
+            for j in range(2, len(d.result.indices)):
+                idx = d.result.indices[j]
+                loop_var = LocalValue(ScalarType(IntegerType.index))
+                start = IntImmValue(IntegerType.index, d.loopRanges[idx].start)
+                stop = IntImmValue(IntegerType.index, d.loopRanges[idx].stop)
+                csa_region = Region(
+                    [ForInst(B_offset_list[j], start, stop, csa_region)])
+            return csa_region
+
+        alpha = LocalValue(self._ty, 'alpha')
+        Abatch = LocalValue(MakeBatchType(d.term), 'A')
+        Bbatch = LocalValue(MakeBatchType(d.result), 'B')
+        kernel = Function('copyscaleadd', [alpha, Abatch, Bbatch], None)
+
+        bb = RegionBuilder()
+        gid = bb.add(GroupIdInst())
+        A = MakeLoad(bb, d.term, Abatch, gid)
+        B = MakeLoad(bb, d.result, Bbatch, gid)
+
+        trans = Transpose.n
+        if len(d.result.indices) == 0:
+            raise NotImplementedError
+        if len(d.result.indices) == 1:
+            bb.extend(MakeLoopOverAxpby(d, 1, Transpose.n, A, B))
+        if len(d.result.indices) >= 2:
+            i0 = d.result.indices[0]
+            i1 = d.result.indices[1]
+            trans = Transpose.t if d.term.indices.find(
+                i0) > d.term.indices.find(i1) else Transpose.n
+            bb.extend(MakeLoopOverAxpby(d, 2, trans, A, B))
+
+        kernel.body = bb.get_product()
+        AssignIdentifiers().visit(kernel)
+
+        args = [
+            TinytcScalarKernelArgument('alpha', str(d.alpha)),
+            TinytcKernelArgument('A', d.term.name, d.term.is_compute_constant,
+                                 d.term.is_temporary, False),
+            TinytcKernelArgument('B', d.result.name,
+                                 d.result.is_compute_constant,
+                                 d.result.is_temporary, True)
+        ]
+        wrapper = TinytcWrapper(kernel, args, self._arch.typename)
+
+        prototype = f'{wrapper.prototype()}'
+        routineCache.addRoutine(prototype,
+                                TinytcWriter(prototype, wrapper.definition()))
+
+        cpp(wrapper.call())
+
+        flops = 1
+        if d.beta != 0.0:
+            flops += 1
+        for rng in d.loopRanges.values():
+            flops *= rng.size()
+        return flops

--- a/yateto/codegen/fused_gemms/tinytc.py
+++ b/yateto/codegen/fused_gemms/tinytc.py
@@ -148,7 +148,7 @@ class FusedGemmsTinytc:
     hasher = hashlib.sha512()
     hasher.update(make_kernel.encode('utf-8'))
     wrapper_name = f'tinytc_wrapper_{hasher.hexdigest()}'
-    wrapper_args = [f'unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME}', f'void* {BatchedOperationsAux.STREAM_PTR_NAME}']
+    wrapper_args = [f'long {BatchedOperationsAux.NUM_ELEMENTS_NAME}', f'void* {BatchedOperationsAux.STREAM_PTR_NAME}']
     wrapper_call_args = []
     call_args = []
     for key in input_matrices.keys():
@@ -161,7 +161,7 @@ class FusedGemmsTinytc:
             wrapper_call_args.append(BatchedOperationsAux.NUM_ELEMENTS_NAME)
         elif not is_constant[key]:
             offset_name = f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{var_name[key]}' 
-            wrapper_args.append(f'int {offset_name}')
+            wrapper_args.append(f'long {offset_name}')
             wrapper_call_args.append(offset_name)
             call_args.append(f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{key}')
     wrapper_call_args = ', '.join(wrapper_call_args)

--- a/yateto/codegen/fused_gemms/tinytc.py
+++ b/yateto/codegen/fused_gemms/tinytc.py
@@ -130,9 +130,7 @@ class FusedGemmsTinytc:
     auto source_ctx = tinytc::make_source_context();
         try {
 	        auto program = tinytc::parse_string(source, source_ctx);
-            auto info = tinytc::make_core_info(queue.get_device());
-	        auto binary = tinytc::compile_to_binary(program, info, tinytc::bundle_format::native, source_ctx);
-	        auto bundle = tinytc::make_kernel_bundle(queue.get_context(), queue.get_device(), binary);
+            auto bundle = tinytc::make_kernel_bundle(queue.get_context(), queue.get_device(), std::move(program), 0, source_ctx);
             auto kernel = tinytc::make_kernel(bundle, "fused_gemm");
             auto group_size = tinytc::get_group_size(kernel);
             return {std::move(kernel), std::move(group_size)};

--- a/yateto/codegen/fused_gemms/tinytc.py
+++ b/yateto/codegen/fused_gemms/tinytc.py
@@ -1,182 +1,126 @@
-from ..common import TensorDescription, IndexedTensorDescription, BatchedOperationsAux
+from ..common import TinytcKernelArgument, TinytcScalarKernelArgument, TinytcWrapper, makeMemrefType, makeBatchType, makeLoad
 from ...ast.indices import BoundingBox
 from ..cache import TinytcWriter
 from ...ast.node import IndexedTensor
 from ...type import Tensor
+from ..tiny_tensor_language import *
 
 import hashlib
 
 
 class FusedGemmsTinytc:
-  def __init__(self, arch, descr):
-    self._arch = arch
-    self._descr = descr
-    self._batch_aux = BatchedOperationsAux(self._arch.typename)
-    self._cache = {}
-    self._tmp_matrices = {}
-    self._scalar_type = 'f64' if self._arch.bytesPerReal == 8 else 'f32'
-    self._var_counter = 0
 
-  def next_var(self):
-    count = self._var_counter
-    self._var_counter += 1
-    return count
+    def __init__(self, arch, descr):
+        self._arch = arch
+        self._descr = descr
+        self._ty = ScalarType(
+            FloatingType.f64) if self._arch.bytesPerReal == 8 else ScalarType(
+                FloatingType.f32)
 
-  def generate(self, cpp, routineCache, cfg):
-    input_matrices = dict()
-    is_constant = dict()
-    is_modified = dict()
-    var_name = dict()
-    work_item_name = dict()
-    self._var_counter = 0
+    def generate(self, cpp, routineCache, cfg):
+        args = dict()
+        vals = dict()
+        is_constant = dict()
+        modified = set()
+        bb = RegionBuilder()
+        gid = bb.add(GroupIdInst())
 
-    def store_matrix(var, node, is_result):
-        if var not in var_name:
-            if var.is_temporary and is_result:
-                var_name[res] = 'tmp'
+        def addVal(var, node):
+            if var not in vals:
+                name = str(var)
+                if not name.startswith('_'):
+                    groups = Tensor.getGroup(name)
+                    name = Tensor.getBaseName(name)
+                    if groups:
+                        name += '_' + '_'.join(str(g) for g in groups)
+                else:
+                    # Names starting with underscore are illegal in tinytc
+                    name = ''
+                is_constant[var] = node.tensor.is_compute_constant(
+                ) if isinstance(node, IndexedTensor) else False
+                arg = LocalValue(
+                    makeBatchType(self._ty, node.memoryLayout(),
+                                  is_constant[var], var.is_temporary), name)
+                args[var] = arg
+                vals[var] = makeLoad(bb, arg, gid, is_constant[var], var.is_temporary)
+
+        flops = 0
+        for item in self._descr:
+            node, variables, add, scalar = item
+            res, op1, op2 = variables
+
+            addVal(op1, node.leftTerm())
+            op1_val = vals[op1]
+            addVal(op2, node.rightTerm())
+            op2_val = vals[op2]
+
+            res_batch = None
+            res_val = None
+            if res.is_temporary:
+                res_val = bb.add(
+                    AllocaInst(
+                        makeMemrefType(self._ty, res.memoryLayout(), False)))
+                vals[res] = res_val
             else:
-                input_matrices[var] = node.memoryLayout()
-                is_constant[var] = node.tensor.is_compute_constant() if isinstance(node, IndexedTensor) else False
-                base_name = str(var)
-                if not base_name.startswith('_'):
-                    base_name = Tensor.getBaseName(base_name)
-                name = base_name
-                counter = 1
-                while name in var_name.values():
-                    name = f'{base_name}{counter}'
-                    counter = counter + 1
-                var_name[var] = name
-        if is_result:
-            is_modified[var] = True
+                modified.add(res)
+                addVal(res, node)
+                res_val = vals[res]
 
-    def batch_type(var):
-        ml = input_matrices[var]
-        if is_constant[var]:
-            return f'{memref_type(ml)}'
-        elif var.is_temporary:
-            return f'{batch_memref_type(ml)}'
-        else:
-            return f'group<{memref_type(ml)}, offset: ?>'
- 
+            bbA = BoundingBox.fromSpp(node.leftTerm().eqspp())
+            bbB = BoundingBox.fromSpp(node.rightTerm().eqspp())
+            bbC = BoundingBox.fromSpp(node.eqspp())
 
-    memref_type = lambda ml: f'memref<{self._scalar_type}x{ml.bboxi(0).size()}x{ml.bboxi(1).size()},strided<1,{ml.stridei(1)}>>'
-    batch_memref_type = lambda ml: f'memref<{self._scalar_type}x{ml.bboxi(0).size()}x{ml.bboxi(1).size()}x?,strided<1,{ml.stridei(1)},{ml.requiredReals()}>>'
+            k_op1 = 0 if node.transA() else 1
+            k_op2 = 1 if node.transB() else 0
+            k = bbA[k_op1] & bbB[k_op2]
+            m = bbA[1 - k_op1]
+            n = bbB[1 - k_op2]
 
-    for item in self._descr:
-      node, args, _, _ = item
-      res, op1, op2 = args
-      store_matrix(res, node, True)
-      store_matrix(op1, node.leftTerm(), False)
-      store_matrix(op2, node.rightTerm(), False)
+            if not node.transA() and node.leftTerm().memoryLayout(
+            ).alignedStride() and node.memoryLayout().alignedStride():
+                m = m.aligned(self._arch)
 
-    args = [f'%{var_name[key]}: {batch_type(key)}' for key in input_matrices.keys()]
-    args_str = ',\n    '.join(args)
-    source = f'func @fused_gemm({args_str}) {{\n'
+            def offsetSizeLists(ml, range0, range1):
+                offsets = (range0.start - ml.bboxi(0).start,
+                           range1.start - ml.bboxi(1).start)
+                sizes = (range0.size(), range1.size())
+                return ([IntImmValue(IntegerType.index, o) for o in offsets],
+                        [IntImmValue(IntegerType.index, s) for s in sizes])
 
-    source += f'    %{self.next_var()} = group_id\n'
-    gid = self._var_counter-1
-    for key in input_matrices.keys():
-        if not is_constant[key]:
-            new_var = self.next_var()
-            if key.is_temporary:
-                source += f'    %{new_var} = load %{var_name[key]}[:,:,%{gid}] : {batch_type(key)}\n'
-            else:
-                source += f'    %{new_var} = load %{var_name[key]}[%{gid}] : {batch_type(key)}\n'
-            work_item_name[key] = str(new_var)
-    
-    flops = 0
-    for item in self._descr:
-      node, args, add, scalar = item
-      res, op1, op2 = args
+            op1_sub = bb.add(
+                SubviewInst(
+                    op1_val,
+                    *offsetSizeLists(node.leftTerm().memoryLayout(), m, k)))
+            op2_sub = bb.add(
+                SubviewInst(
+                    op2_val,
+                    *offsetSizeLists(node.rightTerm().memoryLayout(), k, n)))
+            res_sub = bb.add(
+                SubviewInst(res_val,
+                            *offsetSizeLists(node.memoryLayout(), m, n)))
 
-      if res.is_temporary:
-        var_name[res] = f'tmp{self.next_var()}'
-        source += f'    %{var_name[res]} = alloca -> {memref_type(node.memoryLayout())}\n'
+            trans = lambda t: Transpose.t if t else Transpose.n
+            alpha = FloatImmValue(self._ty, scalar)
+            beta = FloatImmValue(self._ty, 1.0 if add else 0.0)
+            bb.add(
+                GemmInst(trans(node.transA()), trans(node.transB()), alpha,
+                         op1_sub, op2_sub, beta, res_sub))
 
-      bbA = BoundingBox.fromSpp(node.leftTerm().eqspp())
-      bbB = BoundingBox.fromSpp(node.rightTerm().eqspp())
-      bbC = BoundingBox.fromSpp(node.eqspp())
-      
-      k_op1 = 0 if node.transA() else 1
-      k_op2 = 1 if node.transB() else 0
-      k = bbA[k_op1] & bbB[k_op2]
-      m = bbA[1 - k_op1]
-      n = bbB[1 - k_op2]
+            flops += 2 * m.size() * n.size() * k.size()
 
-      if not node.transA() and node.leftTerm().memoryLayout().alignedStride() and node.memoryLayout().alignedStride():
-          m = m.aligned(self._arch)
+        kernel = Function('fused_gemm', args.values(), bb.get_product())
+        AssignIdentifiers().visit(kernel)
 
-      slic = lambda r, i: f'{i.start-r.start}:{i.stop-i.start}'
-      name = lambda var: work_item_name[var] if var in work_item_name else var_name[var]
-      subview = lambda var, ml, range1, range2: (f'    %{self.next_var()} = subview %{name(var)}[{slic(ml.bboxi(0), range1)},{slic(ml.bboxi(1), range2)}] : {memref_type(ml)}\n', f'memref<{self._scalar_type}x{range1.stop-range1.start}x{range2.stop-range2.start},strided<1,{ml.stridei(1)}>>')
-      trans = lambda t: 't' if t else 'n'
+        wrapper_args = []
+        for key, val in args.items():
+            name = f'_tmp{val.name}' if val.name.isnumeric() else val.name
+            wrapper_args.append(
+                TinytcKernelArgument(name, str(key), is_constant[key],
+                                     key.is_temporary, key in modified))
+        wrapper = TinytcWrapper(kernel, wrapper_args, self._arch.typename)
+        cpp(wrapper.call())
+        prototype = wrapper.prototype()
+        routineCache.addRoutine(prototype,
+                                TinytcWriter(prototype, wrapper.definition()))
 
-      op1_sub, op1_sub_ty = subview(op1, node.leftTerm().memoryLayout(), m, k)
-      op2_sub, op2_sub_ty = subview(op2, node.rightTerm().memoryLayout(), k, n)
-      res_sub, res_sub_ty = subview(res, node.memoryLayout(), m, n)
-      source += op1_sub + op2_sub + res_sub
-      source += f'    gemm.{trans(node.transA())}.{trans(node.transB())} {scalar}, %{self._var_counter-3}, %{self._var_counter-2}, {1.0 if add else 0.0}, %{self._var_counter-1} : {self._scalar_type}, {op1_sub_ty}, {op2_sub_ty}, {self._scalar_type}, {res_sub_ty}\n';
-
-      flops += 2 * m.size() * n.size() * k.size() 
-
-    source += '}\n'
-
-    make_kernel = """    struct custom_kernel { ::sycl::kernel kernel; ::sycl::range<3u> group_size; };
-    static auto k = [&] (::sycl::queue const& queue) -> custom_kernel {
-        static const std::string source = R\"tinytc(
-"""
-    make_kernel += source
-    make_kernel += """)tinytc\";
-    auto source_ctx = tinytc::make_source_context();
-        try {
-	        auto program = tinytc::parse_string(source, source_ctx);
-            auto bundle = tinytc::make_kernel_bundle(queue.get_context(), queue.get_device(), std::move(program), 0, source_ctx);
-            auto kernel = tinytc::make_kernel(bundle, "fused_gemm");
-            auto group_size = tinytc::get_group_size(kernel);
-            return {std::move(kernel), std::move(group_size)};
-        } catch (tinytc::status const& st) {
-            throw std::runtime_error(source_ctx.get_error_log());
-        }
-    }""";
-    make_kernel += f'(*static_cast<::sycl::queue*>({BatchedOperationsAux.STREAM_PTR_NAME}));\n'
-
-    def wrapper_type(key):
-        ptr2ptr = '*' if not is_constant[key] and not key.is_temporary else ''
-        const = ' const' if key not in is_modified and not key.is_temporary else ''
-        return f'{self._arch.typename}{const}*{ptr2ptr}'
-
-    hasher = hashlib.sha512()
-    hasher.update(make_kernel.encode('utf-8'))
-    wrapper_name = f'tinytc_wrapper_{hasher.hexdigest()}'
-    wrapper_args = [f'long {BatchedOperationsAux.NUM_ELEMENTS_NAME}', f'void* {BatchedOperationsAux.STREAM_PTR_NAME}']
-    wrapper_call_args = []
-    call_args = []
-    for key in input_matrices.keys():
-        ptr2ptr = '*' if not is_constant[key] and not key.is_temporary else ''
-        const = ' const' if key not in is_modified and not key.is_temporary else ''
-        wrapper_args += [f'{wrapper_type(key)} {var_name[key]}']
-        wrapper_call_args += [var_name[key]]
-        call_args += [f'const_cast<{wrapper_type(key)}>({str(key)})']
-        if key.is_temporary:
-            wrapper_call_args.append(BatchedOperationsAux.NUM_ELEMENTS_NAME)
-        elif not is_constant[key]:
-            offset_name = f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{var_name[key]}' 
-            wrapper_args.append(f'long {offset_name}')
-            wrapper_call_args.append(offset_name)
-            call_args.append(f'{BatchedOperationsAux.EXTRA_OFFSET_NAME}_{key}')
-    wrapper_call_args = ', '.join(wrapper_call_args)
-    call_args = ', '.join(call_args)
-    wrapper_signature = f'void {wrapper_name}({", ".join(wrapper_args)});'
-    wrapper = f'{wrapper_signature[:-1]} {{\n'
-    wrapper += make_kernel
-    wrapper += f'    static_cast<::sycl::queue*>({BatchedOperationsAux.STREAM_PTR_NAME})->submit([&](::sycl::handler &h) {{\n';
-    wrapper += f'        h.set_args({wrapper_call_args});\n'
-    wrapper += f'        h.parallel_for(::sycl::nd_range{{tinytc::get_global_size({BatchedOperationsAux.NUM_ELEMENTS_NAME}, k.group_size), k.group_size}}, k.kernel);\n'
-    wrapper +=  '    });\n'
-    wrapper += '}\n\n'
-
-    cpp(f'{wrapper_name}({BatchedOperationsAux.NUM_ELEMENTS_NAME}, {BatchedOperationsAux.STREAM_PTR_NAME}, {call_args});')
-
-    routineCache.addRoutine(wrapper_signature, TinytcWriter(wrapper_signature, wrapper))
-
-    return flops
+        return flops

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -521,7 +521,7 @@ class TinytcGemmGen(GpuRoutineGenerator):
     starsA = stars(self.gemm_descr['addrA'])
     starsB = stars(self.gemm_descr['addrB'])
     starsC = stars(self.gemm_descr['addrC'])
-    return f'void {routineName}({typ} const{starsA} A, int offsetA, {typ} const{starsB} B, int offsetB, {typ}{starsC} C, int offsetC, unsigned {BatchedOperationsAux.NUM_ELEMENTS_NAME}, void* {BatchedOperationsAux.STREAM_PTR_NAME})'
+    return f'void {routineName}({typ} const{starsA} A, long offsetA, {typ} const{starsB} B, long offsetB, {typ}{starsC} C, long offsetC, long {BatchedOperationsAux.NUM_ELEMENTS_NAME}, void* {BatchedOperationsAux.STREAM_PTR_NAME})'
 
   def memref_type(self, addr, M, N, stride, dist):
       if addr == 'pointer_based':
@@ -541,7 +541,7 @@ class TinytcGemmGen(GpuRoutineGenerator):
       Operand = namedtuple('Operand', ['name', 'addr', 'rows', 'cols', 'ld', 'dist'])
       def data_type(op):
         if op.addr == 'pointer_based':
-          return f'group<memref<{scalar_ty}x{op.rows}x{op.cols},strided<1,{op.ld}>, offset: ?>'
+          return f'group<memref<{scalar_ty}x{op.rows}x{op.cols},strided<1,{op.ld}>>, offset: ?>'
         elif op.addr == 'strided':
           return f'memref<{scalar_ty}x{op.rows}x{op.cols}x?,strided<1,{op.ld},{op.dist}>>'
         elif op.addr == 'none':
@@ -552,9 +552,9 @@ class TinytcGemmGen(GpuRoutineGenerator):
         if op.addr == 'pointer_based':
           return f'load %{op.name}[%gid] : {data_type(op)}'
         elif op.addr == 'strided':
-          return f'load %{op.name}[:,:,%gid] : {data_type(op)}'
+          return f'subview %{op.name}[:,:,%gid] : {data_type(op)}'
         elif op.addr == 'none':
-          return f'load %{op.name}[:,:] : {data_type(op)}'
+          return f'subview %{op.name}[:,:] : {data_type(op)}'
         else:
           raise NameError(op.addr)
       def mat_type(op):

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -596,9 +596,7 @@ func @gemm(""")
     auto source_ctx = tinytc::make_source_context();
         try {
 	        auto program = tinytc::parse_string(source, source_ctx);
-            auto info = tinytc::make_core_info(queue.get_device());
-	        auto binary = tinytc::compile_to_binary(program, info, tinytc::bundle_format::native, source_ctx);
-	        auto bundle = tinytc::make_kernel_bundle(queue.get_context(), queue.get_device(), binary);
+            auto bundle = tinytc::make_kernel_bundle(queue.get_context(), queue.get_device(), std::move(program), 0, source_ctx);
 	        auto kernel = tinytc::make_kernel(bundle, "gemm");
             auto group_size = tinytc::get_group_size(kernel);
             return {std::move(kernel), std::move(group_size)};

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -612,7 +612,7 @@ func @gemm(""")
       f.write(f"""    static_cast<::sycl::queue*>({BatchedOperationsAux.STREAM_PTR_NAME})->submit([&](::sycl::handler &h) {{
         h.set_args({args_str});
         h.parallel_for(::sycl::nd_range{{tinytc::get_global_size({BatchedOperationsAux.NUM_ELEMENTS_NAME}, k.group_size), k.group_size}}, k.kernel);
-    }}).wait();
+    }});
 }}
 """)
 

--- a/yateto/codegen/test_framework.py
+++ b/yateto/codegen/test_framework.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 
 class TestFramework(ABC):
+    def __init__(self, arch):
+        self.arch = arch
+
     @abstractmethod
     def functionArgs(self, testName):
         """functionArgs.
@@ -27,6 +30,8 @@ class TestFramework(ABC):
         cpp.include(kernelsInclude)
         cpp.include(initInclude)
         cpp.include('yateto.h')
+        if self.arch.backend == 'oneapi':
+            cpp.includeSys('sycl/sycl.hpp')
         with cpp.PPIfndef('NDEBUG'):
             with cpp.PPIfndef('YATETO_TESTING_NO_FLOP_COUNTER'):
                 cpp('long long libxsmm_num_total_flops = 0;')
@@ -36,6 +41,9 @@ class CxxTest(TestFramework):
     TEST_CLASS = 'KernelTestSuite'
     TEST_NAMESPACE = 'unit_test'
     TEST_PREFIX = 'test'
+
+    def __init__(self, arch):
+        super().__init__(arch)
 
     def functionArgs(self, testName):
         return {'name': self.TEST_PREFIX + testName}
@@ -55,6 +63,9 @@ class CxxTest(TestFramework):
 
 class Doctest(TestFramework):
     TEST_CASE = 'yateto kernels'
+
+    def __init__(self, arch):
+        super().__init__(arch)
 
     def functionArgs(self, testName):
         """functionArgs.

--- a/yateto/codegen/tiny_tensor_language.py
+++ b/yateto/codegen/tiny_tensor_language.py
@@ -132,6 +132,15 @@ class Arithmetic(Enum):
     rem = 4
 
 
+class AllocaInst(Inst):
+
+    def __init__(self, ty: MemrefType):
+        self.result = LocalValue(ty)
+
+    def value(self):
+        return self.result
+
+
 class AxpbyInst(Inst):
 
     def __init__(self,
@@ -188,14 +197,6 @@ class GemmInst(Inst):
         return None
 
 
-#class AllocaInst(ValueInst):
-#
-#    def __init__(self, ty: MemrefType):
-#        self.value = Value(ty)
-#
-#    def value(self):
-#        return self.value
-#
 class GroupIdInst(Inst):
 
     def __init__(self):
@@ -316,6 +317,9 @@ class Traversal(Visitor):
     def visit_FloatImmValue(self, node):
         pass
 
+    def visit_AllocaInst(self, node):
+        self.visit(node.result)
+
     def visit_AxpbyInst(self, node):
         self.visit(node.alpha)
         self.visit(node.a)
@@ -420,6 +424,9 @@ class Dump(Visitor):
 
     def visit_LocalValue(self, node):
         return f'%{node.name}'
+
+    def visit_AllocaInst(self, node):
+        return f'{self.visit(node.value())} = alloca -> {self.visit(node.value().type())}'
 
     def visit_AxpbyInst(self, node):
         opcode = f'axpby.{node.trans.name}'

--- a/yateto/codegen/tiny_tensor_language.py
+++ b/yateto/codegen/tiny_tensor_language.py
@@ -1,0 +1,432 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+from enum import Enum
+from abc import ABC, abstractmethod
+from typing import Optional, Union, List
+from ..ast.visitor import Visitor
+
+# Data types
+
+DYNAMIC = -9223372036854775808
+
+
+def format_mode(mode):
+    return '?' if mode == DYNAMIC else str(mode)
+
+
+class DataType(ABC):
+    pass
+
+
+class IntegerType(Enum):
+    i1 = 0,
+    i8 = 1,
+    i16 = 2,
+    i32 = 3,
+    i64 = 4,
+    index = 5
+
+
+class FloatingType(Enum):
+    f32 = 0,
+    f64 = 1
+
+
+class ScalarType(DataType):
+
+    def __init__(self, ty: Enum):
+        self.ty = ty
+
+
+class MemrefType(DataType):
+
+    def __init__(self, ty: ScalarType, shape: tuple[int], stride: tuple[int]):
+        self.ty = ty
+        self.shape = shape
+        self.stride = stride
+
+    def order(self):
+        return len(self.shape)
+
+
+class GroupType(DataType):
+
+    def __init__(self, ty: MemrefType, offset: Optional[int] = 0):
+        self.ty = ty
+        self.offset = offset
+
+
+# Value
+
+
+class Value(ABC):
+
+    @abstractmethod
+    def type(self):
+        pass
+
+
+class IntImmValue(Value):
+
+    def __init__(self, ty: IntegerType, value: int):
+        self.ty = ty
+        self.value = value
+
+    def type(self):
+        return self.ty
+
+
+class FloatImmValue(Value):
+
+    def __init__(self, ty: FloatingType, value: float):
+        self.ty = ty
+        self.value = value
+
+    def type(self):
+        return self.ty
+
+
+class LocalValue(Value):
+
+    def __init__(self, ty: DataType, name: str = ""):
+        self.ty = ty
+        self.name = name
+
+    def type(self):
+        return self.ty
+
+
+# Inst
+
+
+class Inst(ABC):
+
+    @abstractmethod
+    def value(self):
+        pass
+
+
+# Region
+
+
+class Region(object):
+
+    def __init__(self, body: list[Inst]):
+        self.body = body
+
+
+# Instructions
+
+
+class Transpose(Enum):
+    n = 0,
+    t = 1
+
+class Arithmetic(Enum):
+    add = 0,
+    sub = 1,
+    mul = 2,
+    div = 3,
+    rem = 4
+
+
+class AxpbyInst(Inst):
+
+    def __init__(self,
+                 trans: Transpose,
+                 alpha: Value,
+                 a: Value,
+                 beta: Value,
+                 b: Value,
+                 atomic: bool = False):
+        self.trans = trans
+        self.alpha = alpha
+        self.a = a
+        self.beta = beta
+        self.b = b
+        self.atomic = atomic
+
+    def value(self):
+        return None
+
+class ArithInst(Inst):
+    def __init__(self, operation_type: Arithmetic, a: Value, b: Value):
+        self.operation_type = operation_type
+        self.a = a
+        self.b = b
+        self.result = LocalValue(a.type())
+
+    def value(self):
+        return self.result
+
+
+#class AllocaInst(ValueInst):
+#
+#    def __init__(self, ty: MemrefType):
+#        self.value = Value(ty)
+#
+#    def value(self):
+#        return self.value
+#
+class GroupIdInst(Inst):
+
+    def __init__(self):
+        self.result = LocalValue(ScalarType(IntegerType.index))
+
+    def value(self):
+        return self.result
+
+
+class LoadInst(Inst):
+
+    def __init__(self, operand: Value, index_list: list[Value]):
+        self.operand = operand
+        self.index_list = index_list
+        self.result = None
+        self.result = LocalValue(operand.type().ty)
+
+    def value(self):
+        return self.result
+
+class ForInst(Inst):
+
+    def __init__(self, loop_var: Value, start: Value, stop: Value,
+                 body: Region):
+        self.loop_var = loop_var
+        self.start = start
+        self.stop = stop
+        self.body = body
+
+    def value(self):
+        return None
+
+class StoreInst(Inst):
+
+    def __init__(self, data: Value, operand: Value, index_list: list[Value]):
+        self.data = data
+        self.operand = operand
+        self.index_list = index_list
+        self.result = LocalValue(operand.type().ty)
+
+    def value(self):
+        return self.result
+
+
+class SubviewInst(Inst):
+
+    def __init__(self, operand: Value, offset_list: list[Value], size_list: list[Value]):
+        if not isinstance(operand.type(), MemrefType):
+            raise RuntimeError('Subview instruction expects memref type')
+        if len(offset_list) != len(size_list) or len(offset_list) != len(operand.type().shape):
+            raise RuntimeError('Subview slice list length must match tensor order')
+
+        sliced_modes = [i for i,v in enumerate(size_list) if v is not None]
+        shape = []
+        stride = []
+        for mode in sliced_modes:
+            size = DYNAMIC
+            if isinstance(size_list[mode], IntImmValue):
+                size = size_list[mode].value
+                if size == DYNAMIC and isinstance(offset_list[mode], IntImmValue) and operand.type().shape[mode] != DYNAMIC:
+                    size = operand.type().shape[mode] - offset_list[mode].value
+            shape.append(size)
+            stride.append(operand.type().stride[mode])
+
+        self.operand = operand
+        self.offset_list = offset_list
+        self.size_list = size_list
+        self.result = LocalValue(MemrefType(operand.type().ty, shape, stride))
+
+    def value(self):
+        return self.result
+
+
+
+
+# Function
+
+
+class Function(object):
+
+    def __init__(self, name: str, args: list[LocalValue], body: Region):
+        self.name = name
+        self.args = args
+        self.body = body
+
+
+class RegionBuilder(object):
+
+    def __init__(self):
+        self.body = []
+
+    def add(self, inst: Inst):
+        self.body.append(inst)
+        return inst.value()
+
+    def extend(self, otherRegion: Region):
+        for inst in otherRegion.body:
+            self.body.append(inst)
+
+    def get_product(self):
+        return Region(self.body.copy())
+
+
+class Traversal(Visitor):
+
+    def generic_visit(self, node):
+        raise NotImplementedError(
+            f'Traversal for {type(node).__name__} not implemented')
+
+    def visit_IntImmValue(self, node):
+        pass
+
+    def visit_FloatImmValue(self, node):
+        pass
+
+    def visit_AxpbyInst(self, node):
+        self.visit(node.alpha)
+        self.visit(node.a)
+        self.visit(node.beta)
+        self.visit(node.b)
+
+    def visit_ArithInst(self, node):
+        self.visit(node.result)
+        self.visit(node.a)
+        self.visit(node.b)
+
+    def visit_LocalValue(self, node):
+        self.visit(node.type())
+
+    def visit_GroupIdInst(self, node):
+        self.visit(node.result)
+
+    def visit_LoadInst(self, node):
+        self.visit(node.result)
+        self.visit(node.operand)
+        for idx in node.index_list:
+            self.visit(idx)
+
+    def visit_ForInst(self, node):
+        self.visit(node.loop_var)
+        self.visit(node.start)
+        self.visit(node.stop)
+        self.visit(node.body)
+
+    def visit_Region(self, node):
+        for inst in node.body:
+            self.visit(inst)
+
+    def visit_Function(self, node):
+        for arg in node.args:
+            self.visit(arg)
+        self.visit(node.body)
+
+    def visit_StoreInst(self, node):
+        self.visit(node.data)
+        self.visit(node.operand)
+        for idx in node.index_list:
+            self.visit(idx)
+
+    def visit_SubviewInst(self, node):
+        self.visit(node.result)
+        self.visit(node.operand)
+        for v in node.offset_list:
+            self.visit(v)
+        for v in node.size_list:
+            if v is not None:
+                self.visit(v)
+
+class AssignIdentifiers(Traversal):
+
+    def __init__(self):
+        self.val_counter = 0
+
+    def visit_LocalValue(self, node):
+        if not node.name:
+            node.name = str(self.val_counter)
+            self.val_counter += 1
+
+
+class Dump(Visitor):
+
+    BASE_INDENT = '  '
+
+    def __init__(self):
+        self.level = 0
+
+    def generic_visit(self, node):
+        raise NotImplementedError(
+            f'Dump for {type(node).__name__} not implemented')
+
+    def visit_ScalarType(self, node):
+        return f'{node.ty.name}'
+
+    def visit_MemrefType(self, node):
+        shape_str = ''
+        for s in node.shape:
+            shape_str += f'x{format_mode(s)}'
+        stride_str = ','.join(format_mode(s) for s in node.stride)
+        return f'memref<{self.visit(node.ty)}{shape_str}, strided<{stride_str}>>'
+
+    def visit_GroupType(self, node):
+        return f'group<{self.visit(node.ty)}, offset: {format_mode(node.offset)}>'
+
+    def visit_IntImmValue(self, node):
+        return f'{format_mode(node.value)}'
+
+    def visit_FloatImmValue(self, node):
+        return f'{node.value}'
+
+    def visit_LocalValue(self, node):
+        return f'%{node.name}'
+
+    def visit_AxpbyInst(self, node):
+        opcode = f'axpby.{node.trans.name}'
+        if node.atomic:
+            opcode += '.atomic'
+        args = (node.alpha, node.a, node.beta, node.b)
+        args_str = ', '.join(self.visit(arg) for arg in args)
+        type_str = ', '.join(self.visit(arg.type()) for arg in args)
+        return f'{opcode} {args_str} : {type_str}'
+
+    def visit_ArithInst(self, node):
+        return f'{self.visit(node.value())} = arith.{node.operation_type.name} {self.visit(node.a)}, {self.visit(node.b)} : {self.visit(node.a.type())}'
+
+    def visit_GroupIdInst(self, node):
+        return f'{self.visit(node.value())} = group_id'
+
+    def visit_LoadInst(self, node):
+        indices = ','.join(self.visit(index) for index in node.index_list)
+        return f'{self.visit(node.value())} = load {self.visit(node.operand)}[{indices}] : {self.visit(node.operand.type())}'
+
+    def visit_ForInst(self, node):
+        loop_range = f'{self.visit(node.loop_var)}={self.visit(node.start)},{self.visit(node.stop)}'
+        return f'for {loop_range} : {self.visit(node.loop_var.type())} {self.visit(node.body)}'
+
+    def visit_StoreInst(self, node):
+        indices = ','.join(self.visit(index) for index in node.index_list)
+        return f'store {self.visit(node.data)}, {self.visit(node.operand)}[{indices}] : {self.visit(node.operand.type())}'
+
+    def visit_SubviewInst(self, node):
+        slice_list = []
+        for offset, size in zip(node.offset_list, node.size_list):
+            if size is not None:
+                slice_list.append(f'{self.visit(offset)}:{self.visit(size)}')
+            else:
+                slice_list.append(f'{self.visit(offset)}')
+        return f'{self.visit(node.value())} = subview {self.visit(node.operand)}[{",".join(slice_list)}] : {self.visit(node.operand.type())}'
+
+    def visit_Region(self, node):
+        self.level += 1
+        indent = self.BASE_INDENT * self.level
+        body_str = f'\n{indent}'.join(self.visit(i) for i in node.body)
+        self.level -= 1
+        return f'{{\n{indent}{body_str}\n{self.BASE_INDENT * self.level}}}'
+
+    def visit_Function(self, node):
+        arg_indent = ' ' * (7 + len(node.name))
+        args_str = f',\n{arg_indent}'.join(
+            f'{self.visit(arg)}: {self.visit(arg.type())}'
+            for arg in node.args)
+        return f'func @{node.name}({args_str}) {self.visit(node.body)}'

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -404,6 +404,9 @@ class OptimisedKernelGenerator(KernelGenerator):
 
 class UnitTestGenerator(KernelGenerator):
   KERNEL_VAR = 'krnl'
+  QUEUE = '_queue'
+  TMP_MEM = '_tmpMem'
+  TMP_SIZE = 128 * 8
   
   def __init__(self, arch):
     super().__init__(arch)
@@ -424,6 +427,22 @@ class UnitTestGenerator(KernelGenerator):
     group = var.tensor.group()
     terms = [baseName] + [str(g) for g in group]
     return '_'.join(terms)
+
+  @classmethod
+  def _devTensorName(cls, var):
+      return f'_dev_{cls._tensorName(var)}'
+
+  @classmethod
+  def _devPtrTensorName(cls, var):
+      return f'_dev_ptr_{cls._tensorName(var)}'
+
+  def _devTensorKernelArgument(self, var, writable):
+    if var.tensor.is_compute_constant():
+      return self._devTensorName(var)
+    elif writable[var.tensor.baseNameWithNamespace()]:
+      return self._devPtrTensorName(var)
+    else:
+      return f'const_cast<{self._arch.typename} const**>({self._devPtrTensorName(var)})'
 
   @classmethod
   def _nameS(cls, var):
@@ -457,7 +476,8 @@ class UnitTestGenerator(KernelGenerator):
     gstr = self._groupStr(var)
     return '({})'.format(gstr) if gstr else ''
   
-  def generate(self, cpp, namespace, testName, kernelClass, cfg, gemm_cfg, testFramework, index=None):
+  def generate(self, cpp, namespace, testName, kernelClass, cfg, target, gemm_cfg, testFramework, index=None):
+    device_test = self._arch.backend == 'oneapi' and target == 'gpu'
     scalars = ScalarsSet().visit(cfg)
     scalars = sorted(scalars, key=str)
     variables = SortedGlobalsList().visit(cfg)
@@ -498,14 +518,47 @@ class UnitTestGenerator(KernelGenerator):
         )
         cpp.emptyline()
 
+      kernelTensorName = self._tensorName
+      if device_test:
+        writable = dict()
+        for var in variables:
+          bn = var.tensor.baseNameWithNamespace()
+          writable[bn] = writable.get(bn, False) or var.writable
+
+        kernelTensorName = lambda var: self._devTensorKernelArgument(var, writable)
+        cpp ( f'auto {self.QUEUE} = sycl::queue{{sycl::property::queue::in_order()}};' )
+        cpp ( f'auto {self.TMP_MEM} = ({self._arch.typename}*) sycl::malloc_device({self.TMP_SIZE}, {self.QUEUE});' )
+        for var in variables:
+          cpp( f'auto {self._devTensorName(var)} = ({self._arch.typename}*) sycl::malloc_device(sizeof({self._tensorName(var)}), {self.QUEUE});' )
+          cpp( f'auto {self._devPtrTensorName(var)} = ({self._arch.typename}**) sycl::malloc_device(sizeof({self._arch.typename}*), {self.QUEUE});' )
+          cpp( f'{self.QUEUE}.memcpy({self._devTensorName(var)}, {self._tensorName(var)}, sizeof({self._tensorName(var)})).wait();' )
+          cpp( f'{self.QUEUE}.memcpy({self._devPtrTensorName(var)}, &{self._devTensorName(var)}, sizeof({self._arch.typename}*)).wait();' )
+        cpp.emptyline()
+
+
       cpp( '{}{}::{} {};'.format(kernel_prefix, OptimisedKernelGenerator.NAMESPACE, kernelClass, self.KERNEL_VAR) )
       for var in scalars:
         cpp( '{}.{}{} = {};'.format(self.KERNEL_VAR, var.baseName(), self._groupIndex(var), self._tensorNameS(var)) )
       for var in variables:
-        cpp( '{}.{}{} = {};'.format(self.KERNEL_VAR, var.tensor.baseName(), self._groupIndex(var.tensor), self._tensorName(var)) )
+        cpp( '{}.{}{} = {};'.format(self.KERNEL_VAR, var.tensor.baseName(), self._groupIndex(var.tensor), kernelTensorName(var)) )
+
+      if device_test:
+        cpp( f'{self.KERNEL_VAR}.numElements = 1;' )
+        cpp( f'{self.KERNEL_VAR}.linearAllocator.initialize({self.TMP_MEM});' )
+        cpp( f'{self.KERNEL_VAR}.streamPtr = &{self.QUEUE};' )
 
       cpp( '{}.{}();'.format(self.KERNEL_VAR, OptimisedKernelGenerator.EXECUTE_NAME + (str(index) if index is not None else '')) )
       cpp.emptyline()
+
+      if device_test:
+        cpp( f'{self.QUEUE}.wait();' )
+        cpp( f'sycl::free({self.TMP_MEM}, {self.QUEUE});' )
+        for var in variables:
+          if var.writable:
+            cpp( f'{self.QUEUE}.memcpy({self._tensorName(var)}, {self._devTensorName(var)}, sizeof({self._tensorName(var)})).wait();' )
+          cpp( f'sycl::free({self._devPtrTensorName(var)}, {self.QUEUE});' )
+          cpp( f'sycl::free({self._devTensorName(var)}, {self.QUEUE});' )
+        cpp.emptyline()
 
       super().generate(cpp, cfg, factory, None, gemm_cfg)
 

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -93,7 +93,7 @@ class KernelGenerator(object):
           prefetchName = '{}.{}'.format(self.PREFETCHVAR_NAME, action.term.node.prefetch.name()) if action.term.node.prefetch is not None else None
           hwFlops += factory.create(action.term.node, action.result, action.term.variableList(), action.add, scalar, prefetchName, routineCache, gemm_cfg)
         else:
-          hwFlops += factory.simple(action.result, action.term, action.add, scalar, routineCache)
+          hwFlops += factory.simple(action.result, action.term, action.add, scalar, routineCache, gemm_cfg)
     return hwFlops, required_tmp_mem
 
 class OptimisedKernelGenerator(KernelGenerator):

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -291,15 +291,15 @@ class Generator(object):
     print('Generating unit tests...')
     def unit_test_body(cpp, testFramework):
         for kernel in self._kernels:
-            UnitTestGenerator(self._arch).generate(cpp, kernel.namespace, kernel.name, kernel.name, kernel.cfg, gemm_cfg, testFramework)
+            UnitTestGenerator(self._arch).generate(cpp, kernel.namespace, kernel.name, kernel.name, kernel.cfg, kernel.target, gemm_cfg, testFramework)
         for family in self._kernelFamilies.values():
             for group, kernel in family.items():
-                UnitTestGenerator(self._arch).generate(cpp, kernel.namespace, kernel.name, family.name, kernel.cfg, gemm_cfg, testFramework, group)
+                UnitTestGenerator(self._arch).generate(cpp, kernel.namespace, kernel.name, family.name, kernel.cfg, kernel.target, gemm_cfg, testFramework, group)
     with Cpp(fUTdoctest.cpp) as cpp:
-        Doctest().generate(cpp, namespace, fKernels.hName, fInit.hName, unit_test_body)
+        Doctest(self._arch).generate(cpp, namespace, fKernels.hName, fInit.hName, unit_test_body)
     with Cpp(fUTcxxtest.h) as cpp:
         with cpp.HeaderGuard(self._headerGuardName(namespace, self.CXXTEST_FILE_NAME.replace('.', '_'))):
-            CxxTest().generate(cpp, namespace, fKernels.hName, fInit.hName, unit_test_body)
+            CxxTest(self._arch).generate(cpp, namespace, fKernels.hName, fInit.hName, unit_test_body)
 
 
     print('Optimizing ASTs...')

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -268,9 +268,6 @@ class Generator(object):
     if not gemm_cfg:
       gemm_cfg = DefaultGeneratorCollection(self._arch)
 
-    for tool in gemm_cfg.gemmTools:
-        print(tool, isinstance(tool, tinytc))
-
     hasTinytc = any([isinstance(tool, tinytc) for tool in gemm_cfg.gemmTools])
     enableFusedGemm = bool(chainforge_spec) or hasTinytc
 


### PR DESCRIPTION
Updates plumbing for Tiny Tensor Compiler (tinytc).

* Add Abstract Syntax Tree for Tiny Tensor Language
* Refactor fused GEMM implementation to generate tinytc-AST instead of code
* Add copyscaleadd for tinytc (Loop-over-AXPBY)
* Make GemmForge optional for oneapi backend, tinytc serves as full replacement
* Update wrapper code to work with tinytc 0.3.1