### PR TITLE
CPU Codegen Adapter Update

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -115,29 +115,28 @@ def _get_name_and_precision(ident):
 def getArchitectureIdentifiedBy(ident):
   name, precision = _get_name_and_precision(ident)
 
-  # NOTE: libxsmm currently supports prefetch only for KNL kernels
   arch = {
     'noarch': Architecture(name, precision, 16, False),
     'wsm': Architecture(name, precision, 16, False),
     'snb': Architecture(name, precision, 32, False),
-    'hsw': Architecture(name, precision, 32, False),
+    'hsw': Architecture(name, precision, 32, True),
     'skx': Architecture(name, precision, 64, True),
     'knc': Architecture(name, precision, 64, False),
     'knl': Architecture(name, precision, 64, True),
-    'naples': Architecture(name, precision, 32, False),
-    'rome': Architecture(name, precision, 32, False),
-    'milan': Architecture(name, precision, 32, False),
+    'naples': Architecture(name, precision, 32, True),
+    'rome': Architecture(name, precision, 32, True),
+    'milan': Architecture(name, precision, 32, True),
     'bergamo': Architecture(name, precision, 64, True),
-    'thunderx2t99': Architecture(name, precision, 16, False),
+    'thunderx2t99': Architecture(name, precision, 16, True),
     'a64fx': Architecture(name, precision, 64, True),
-    'neon': Architecture(name, precision, 16, False),
-    'apple-m1': Architecture(name, precision, 16, False),
-    'apple-m2': Architecture(name, precision, 16, False),
-    'sve128': Architecture(name, precision, 16, False),
-    'sve256': Architecture(name, precision, 32, False),
-    'sve512': Architecture(name, precision, 64, False),
-    'sve1024': Architecture(name, precision, 128, False),
-    'sve2048': Architecture(name, precision, 256, False),
+    'neon': Architecture(name, precision, 16, True),
+    'apple-m1': Architecture(name, precision, 16, True),
+    'apple-m2': Architecture(name, precision, 16, True),
+    'sve128': Architecture(name, precision, 16, True),
+    'sve256': Architecture(name, precision, 32, True),
+    'sve512': Architecture(name, precision, 64, True),
+    'sve1024': Architecture(name, precision, 128, True),
+    'sve2048': Architecture(name, precision, 256, True),
     'power9': Architecture(name, precision, 16, False),
   }
   return arch[name]

--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -133,6 +133,8 @@ def getArchitectureIdentifiedBy(ident):
     'neon': Architecture(name, precision, 16, True),
     'apple-m1': Architecture(name, precision, 16, True),
     'apple-m2': Architecture(name, precision, 16, True),
+    'apple-m3': Architecture(name, precision, 16, True),
+    'apple-m4': Architecture(name, precision, 16, True),
     'sve128': Architecture(name, precision, 16, True),
     'sve256': Architecture(name, precision, 32, True),
     'sve512': Architecture(name, precision, 64, True),

--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -127,6 +127,7 @@ def getArchitectureIdentifiedBy(ident):
     'rome': Architecture(name, precision, 32, True),
     'milan': Architecture(name, precision, 32, True),
     'bergamo': Architecture(name, precision, 64, True),
+    'turin': Architecture(name, precision, 64, True),
     'thunderx2t99': Architecture(name, precision, 16, True),
     'a64fx': Architecture(name, precision, 64, True),
     'neon': Architecture(name, precision, 16, True),
@@ -138,6 +139,11 @@ def getArchitectureIdentifiedBy(ident):
     'sve1024': Architecture(name, precision, 128, True),
     'sve2048': Architecture(name, precision, 256, True),
     'power9': Architecture(name, precision, 16, False),
+    'rvv128': Architecture(name, precision, 16, True),
+    'rvv256': Architecture(name, precision, 32, True),
+    'rvv512': Architecture(name, precision, 64, True),
+    'rvv1024': Architecture(name, precision, 128, True),
+    'rvv2048': Architecture(name, precision, 256, True)
   }
   return arch[name]
 

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -190,7 +190,7 @@ class GemmGen(object):
         'beta':         self._beta(d.beta),
         'alignedA':     int(d.alignedA),
         'alignedC':     int(d.alignedC),
-        'prefetch':     'BL2viaC' if self._arch.enablePrefetch and d.prefetchName is not None else 'pfsigonly',
+        'prefetch':     'BL2viaC' if self._arch.enablePrefetch and d.prefetchName is not None else None,
         'transA': d.transA,
         'transB': d.transB,
 
@@ -290,9 +290,7 @@ Stderr: {result.stderr}""")
         self._gemmDescr['alpha'],
         self._gemmDescr['beta'],
         '--arch',
-        pspamm_arch, 
-        '--prefetching',
-        self._gemmDescr['prefetch'],
+        pspamm_arch,
         '--output_funcname',
         routineName,
         '--output_filename',
@@ -300,6 +298,8 @@ Stderr: {result.stderr}""")
         '--precision',
         self._arch.precision
       ]
+      if self._gemmDescr['prefetch']:
+        argList.extend(['--prefetching', self._gemmDescr['prefetch']])
       if self._gemmDescr['transA']:
         argList.extend(['--atranspose', 'true'])
       if self._gemmDescr['transB']:
@@ -330,7 +330,7 @@ Stderr: {result.stderr}""")
         self._gemmDescr['alignedA'],
         self._gemmDescr['alignedC'],
         libxsmm_arch, # libxsmm has no support for rome, hsw works well in practice
-        self._gemmDescr['prefetch'],
+        self._gemmDescr['prefetch'] if self._gemmDescr['prefetch'] else 'nopf',
         self._arch.precision + 'P'
       ]
     class SparsityWrapper:
@@ -370,7 +370,9 @@ Stderr: {result.stderr}""")
           if afile is not None:
             argList.extend(['--amtx_filename', afile])
           if bfile is not None:
-            argList.extend(['--bmtx_filename', bfile])
+            # actually bmtx_filename
+            # take mtx_filename (alias) instead for backwards compatibility
+            argList.extend(['--mtx_filename', bfile])
         self._callGenerator(argList)
 
     if self._mode == 'pspamm':

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -269,7 +269,7 @@ Stderr: {result.stderr}""")
       pspamm_arch = cpu_arch
       if cpu_arch == 'a64fx':
         pspamm_arch = 'arm_sve512'
-      elif cpu_arch in ['apple-m1', 'thunderx2t99', 'neon']:
+      elif cpu_arch in ['thunderx2t99', 'neon'] or cpu_arch.startswith('apple-m'):
         pspamm_arch = 'arm'
       elif cpu_arch.startswith('sve'):
         pspamm_arch = f'arm_{cpu_arch}' # TODO(David): rename to sveLEN only
@@ -277,7 +277,7 @@ Stderr: {result.stderr}""")
         # names are Zen1, Zen2, Zen3, respectively
         # no explicit support for these archs yet, but they have the same instruction sets (AVX2+FMA3) that HSW also needs
         pspamm_arch = 'hsw'
-      elif cpu_arch in ['bergamo']:
+      elif cpu_arch in ['bergamo', 'turin']:
         pspamm_arch = 'skx'
       argList = [
         self._cmd,
@@ -312,7 +312,7 @@ Stderr: {result.stderr}""")
         # names are Zen1, Zen2, Zen3, respectively
         # no explicit support for these archs yet, but they have the same instruction sets (AVX2+FMA3) that HSW also needs
         libxsmm_arch = 'hsw'
-      elif cpu_arch in ['bergamo']:
+      elif cpu_arch in ['bergamo', 'turin']:
         libxsmm_arch = 'skx'
       argList = [
         self._cmd,

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -410,10 +410,9 @@ class LibxsmmGemmGen(ExecuteGemmGen):
   def __init__(self,
                arch,
                gemm_descr,
-               spp,
-               spp_rows,
+               sppA, sppARows, sppB, sppBRows,
                gemm_cfg):
-    super().__init__(arch, gemm_descr, spp, spp_rows, gemm_cfg)
+    super().__init__(arch, gemm_descr, sppA, sppARows, sppB, sppBRows, gemm_cfg)
 
   def header(self, cpp):
     super().header(cpp)

--- a/yateto/codegen/gemm/gemmgen.py
+++ b/yateto/codegen/gemm/gemmgen.py
@@ -2,6 +2,7 @@ import hashlib
 import subprocess
 import tempfile
 from abc import ABC
+import numpy as np
 
 from ..cache import RoutineGenerator, GpuRoutineGenerator
 from ...gemm_configuration import BLASlike, CodeGenerator, GemmForge
@@ -28,25 +29,39 @@ class GemmGen(object):
   def _is_special(self, value, specials):
     result = 'generic'
     try:
-      candidate = int(value)
-      if candidate in specials:
-        result = candidate
+      candidate = float(value)
+      for special in specials:
+        if abs(candidate - special) < 1e-10:
+          result = special
+          break
     except:
       pass
+    result = str(result).replace('-', 'm').replace('.', 'd')
     return result
 
   def _alpha(self, alpha):
-    return self._is_special(alpha, {1})
+    specials = {-1,1} if self._mode == 'pspamm' else {1}
+    return self._is_special(alpha, specials)
 
   def _beta(self, beta):
     return self._is_special(beta, {0,1})
 
-  def generateRoutineName(self, gemm, spp):
+  def generateRoutineName(self, gemm, sppA, sppB):
     name = self._gemm_cfg.operation_name
-    if spp is not None:
+    name += '_' + {
+      (True, True): 'dense',
+      (True, False): 'bsparse',
+      (False, True): 'asparse',
+      (False, False): 'absparse'
+    }[(sppA is None, sppB is None)]
+    if sppA is not None:
       sha = hashlib.md5()
-      sha.update(str(spp).encode())
-      name += 'sparse_' + sha.hexdigest()
+      sha.update(str(sppA).encode())
+      name += '_' + sha.hexdigest()
+    if sppB is not None:
+      sha = hashlib.md5()
+      sha.update(str(sppB).encode())
+      name += '_' + sha.hexdigest()
     return '{name}_m{M}_n{N}_k{K}_ldA{LDA}_ldB{LDB}_ldC{LDC}_alpha{alphaSubs}_beta{betaSubs}_alignedA{alignedA}_alignedC{alignedC}_transA{transA}_transB{transB}_{prefetch}'.format(
       name=name,
       alphaSubs=self._alpha(gemm['alpha']),
@@ -74,17 +89,30 @@ class GemmGen(object):
     assert (d.transB and (n,k) in d.rightTerm.memoryLayout) or (not d.transB and (k,n) in d.rightTerm.memoryLayout)
     assert (m,n) in d.result.memoryLayout
 
-    spp = None
-    sppRows = None
+    sppA = None
+    sppARows = None
+    sppB = None
+    sppBRows = None
     flops = 0
     if d.isACsc:
-      spp = d.leftTerm.memoryLayout.entries(m, k)
-      sppRows = d.leftTerm.memoryLayout.shape()[0]
-      flops = 2 * len(spp) * n.size()
+      sppA = d.leftTerm.memoryLayout.entries(m, k)
+      sppARows = d.leftTerm.memoryLayout.shape()[0]
+    if d.isBCsc:
+      sppB = d.rightTerm.memoryLayout.entries(k, n)
+      sppBRows = d.rightTerm.memoryLayout.shape()[0]
+    
+    if d.isACsc and d.isBCsc:
+      # count the flops by splitting into outer products (i.e. partition by k)
+      # for each outer product, we need to compute all-by-all nonzero entries for m and n
+      # in essence: flops = 2 * sum(1 for ae in sppA for be in sppB if ae[1] == be[0]); then simplify this calculation
+
+      mcount = np.bincount([kk for _,kk in sppA], minlength=k.size())
+      ncount = np.bincount([kk for kk,_ in sppB], minlength=k.size())
+      flops = 2 * int(np.dot(ncount, mcount))
+    elif d.isACsc:
+      flops = 2 * n.size() * len(sppA)
     elif d.isBCsc:
-      spp = d.rightTerm.memoryLayout.entries(k, n)
-      sppRows = d.rightTerm.memoryLayout.shape()[0]
-      flops = 2 * m.size() * len(spp)
+      flops = 2 * m.size() * len(sppB)
     else:
       flops = 2 * m.size() * n.size() * k.size()
     
@@ -168,8 +196,7 @@ class GemmGen(object):
 
       }
 
-      routineName = self.generateRoutineName(gemm, spp)
-
+      routineName = self.generateRoutineName(gemm, sppA, sppB)
 
       if self._mode == 'pspamm':
         cpp( '{}({}, {}, {}, {}, {}, {});'.format(
@@ -194,16 +221,18 @@ class GemmGen(object):
         routineCache.addRoutine(routineName, LibxsmmGemmGen(
           self._arch, gemm, spp, sppRows, self._gemm_cfg))
       else:
-        routineCache.addRoutine(routineName, ExecuteGemmGen(self._arch, gemm, spp, sppRows, self._gemm_cfg))
+        routineCache.addRoutine(routineName, ExecuteGemmGen(self._arch, gemm, sppA, sppARows, sppB, sppBRows, self._gemm_cfg))
 
     return flops
 
-class ExecuteGemmGen(RoutineGenerator):  
-  def __init__(self, arch, gemmDescr, spp, sppRows, gemm_cfg):
+class ExecuteGemmGen(RoutineGenerator):
+  def __init__(self, arch, gemmDescr, sppA, sppARows, sppB, sppBRows, gemm_cfg):
     self._arch = arch
     self._gemmDescr = gemmDescr
-    self._spp = spp
-    self._sppRows = sppRows
+    self._sppA = sppA
+    self._sppARows = sppARows
+    self._sppB = sppB
+    self._sppBRows = sppBRows
     self._mode = gemm_cfg.operation_name
     self._cmd = gemm_cfg.cmd
     self._blockSize = gemm_cfg.blockSize(gemmDescr['M'], gemmDescr['N'], gemmDescr['K']) if hasattr(gemm_cfg, 'blockSize') else dict()
@@ -211,7 +240,7 @@ class ExecuteGemmGen(RoutineGenerator):
   def __eq__(self, other):
     return self._arch == other._arch and \
            self._gemmDescr == other._gemmDescr and \
-           self._spp == other._spp
+           self._sppA == other._sppA and self._sppB == other._sppB
   
   def header(self, cpp):
     with cpp.PPIfndef('NDEBUG'):
@@ -224,7 +253,7 @@ class ExecuteGemmGen(RoutineGenerator):
     resultCode = 1
     try:
       strcmd = [str(arg) for arg in argList]
-      result = subprocess.run(strcmd)
+      result = subprocess.run(strcmd, capture_output=True, text=True)
     except OSError:
       raise RuntimeError(f'GEMM code generator executable "{self._cmd}" not found. (Make sure to add the folder containing the executable to your PATH environment variable.)')
     if result.returncode != 0:
@@ -271,6 +300,10 @@ Stderr: {result.stderr}""")
         '--precision',
         self._arch.precision
       ]
+      if self._gemmDescr['transA']:
+        argList.extend(['--atranspose', 'true'])
+      if self._gemmDescr['transB']:
+        argList.extend(['--btranspose', 'true'])
       for key, val in self._blockSize.items():
         argList.extend(['--' + key, val])
     else:
@@ -300,27 +333,45 @@ Stderr: {result.stderr}""")
         self._gemmDescr['prefetch'],
         self._arch.precision + 'P'
       ]
-    if self._spp is not None:
-      cols = self._gemmDescr['K'] if self._gemmDescr['LDA'] == 0 else self._gemmDescr['N']
-      rows = self._gemmDescr['M'] if self._gemmDescr['LDA'] == 0 else self._gemmDescr['K']
-      if self._mode == 'pspamm':
-        rows = self._sppRows
-      shape = (rows, cols)      
-      with tempfile.NamedTemporaryFile() as temp:
-        temp.write('%%MatrixMarket matrix coordinate real general\n'.encode())
-        temp.write('%\n'.encode())
-        temp.write('{} {} {}\n'.format(shape[0], shape[1], len(self._spp)).encode())
-        for r,c in self._spp:
-          temp.write('{} {} 1.0\n'.format(r+1,c+1).encode())
-        temp.flush()
+    class SparsityWrapper:
+      def __init__(self, shape, spp):
+        self._shape = shape
+        self._spp = spp
+        self._temp = None
+      
+      def __enter__(self):
+        if self._spp is not None:
+          self._temp = tempfile.NamedTemporaryFile()
+          self._temp.__enter__()
+          self._temp.write('%%MatrixMarket matrix coordinate real general\n'.encode())
+          self._temp.write('%\n'.encode())
+          self._temp.write('{} {} {}\n'.format(self._shape[0], self._shape[1], len(self._spp)).encode())
+          for r,c in self._spp:
+            self._temp.write('{} {} 1.0\n'.format(r+1,c+1).encode())
+          self._temp.flush()
+          return self._temp.name
+        return None
+      
+      def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._spp is not None:
+          self._temp.__exit__(exc_type, exc_val, exc_tb)
+    
+    with SparsityWrapper((self._gemmDescr['M'], self._gemmDescr['K']), self._sppA) as afile:
+      with SparsityWrapper((self._sppBRows if self._mode=='pspamm' else self._gemmDescr['K'], self._gemmDescr['N']), self._sppB) as bfile:
         if self._mode == 'libxsmm':
-          argList[1] = 'sparse'
+          assert afile is None or bfile is None
+          if afile is not None:
+            argList[1] = 'sparse'
+            argList.append(afile)
+          if bfile is not None:
+            argList[1] = 'sparse'
+            argList.append(bfile)
         if self._mode == 'pspamm':
-          argList.append('--mtx_filename')
-        argList.append(temp.name)
+          if afile is not None:
+            argList.extend(['--amtx_filename', afile])
+          if bfile is not None:
+            argList.extend(['--bmtx_filename', bfile])
         self._callGenerator(argList)
-    else:
-      self._callGenerator(argList)
 
     if self._mode == 'pspamm':
       return 'void {name}(const {type}* A, const {type}* B, {type}* C, {type} alpha, {type} beta, const {type}* prefetch);'.format(name=routineName, type=self._arch.typename)

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -162,7 +162,7 @@ class LIBXSMM_JIT(CodeGenerator):
     return Preference.LOW
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512', 'apple-m1', "apple-m2"}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', 'turin', "a64fx", "thunderx2t99", 'neon', 'sve128', 'sve256', 'sve512', 'apple-m1', "apple-m2", "apple-m3", "apple-m4"}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -184,7 +184,7 @@ class LIBXSMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo'}
+    supported_set = {'noarch', 'wsm', 'snb', 'hsw', 'skx', 'knc', 'knl', 'naples', 'rome', 'milan', 'bergamo', 'turin'}
 
     if self._arch.name.lower() in supported_set:
       return True
@@ -210,7 +210,7 @@ class PSpaMM(CodeGenerator):
     self._threshold = threshold
 
   def _archSupported(self):
-    supported_set = {'thunderx2t99', 'knl', 'skx', 'a64fx', 'hsw', 'naples', 'rome', 'milan', 'bergamo', 'neon', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048', 'apple-m1', 'apple-m2'}
+    supported_set = {'rvv128', 'rvv256', 'rvv512', 'rvv1024', 'rvv2048', 'thunderx2t99', 'knl', 'skx', 'a64fx', 'hsw', 'naples', 'rome', 'milan', 'bergamo', 'turin', 'neon', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048', 'apple-m1', 'apple-m2', "apple-m3", "apple-m4"}
     if self._arch.name.lower() in supported_set:
       return True
     else:
@@ -302,6 +302,7 @@ class DefaultGeneratorCollection(GeneratorCollection):
       'rome' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
       'milan' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
       'bergamo' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
+      'turin' : [libxsmm_jit, libxsmm, pspamm, blis, eigen],
       'knl' : [libxsmm_jit, libxsmm, pspamm, mkl, blis, eigen],
       'skx' : [libxsmm_jit, libxsmm, pspamm, mkl, blis, eigen],
       'thunderx2t99' : [libxsmm_jit, pspamm, openblas, blis, eigen],
@@ -314,7 +315,12 @@ class DefaultGeneratorCollection(GeneratorCollection):
       'sve512' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'sve1024' : [pspamm, openblas, blis, eigen],
       'sve2048' : [pspamm, openblas, blis, eigen],
-      'power9' : [openblas, blis, eigen]
+      'power9' : [openblas, blis, eigen],
+      'rvv128': [pspamm, eigen],
+      'rvv256': [pspamm, eigen],
+      'rvv512': [pspamm, eigen],
+      'rvv1024': [pspamm, eigen],
+      'rvv2048': [pspamm, eigen]
     }
 
     if arch.name in defaults:

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -308,6 +308,8 @@ class DefaultGeneratorCollection(GeneratorCollection):
       'thunderx2t99' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'apple-m1' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'apple-m2' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'apple-m3' : [libxsmm_jit, pspamm, openblas, blis, eigen],
+      'apple-m4' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'a64fx' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'neon' : [libxsmm_jit, pspamm, openblas, blis, eigen],
       'sve128' : [libxsmm_jit, pspamm, openblas, blis, eigen],

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -219,11 +219,13 @@ class PSpaMM(CodeGenerator):
 
   def supported(self, m, n, k, sparseA, sparseB, transA, transB, alpha,
                 beta, alignedA, alignedC, target):
-    return self._archSupported() and alignedA and alignedC and \
-           not sparseA and (not transA and not transB) and target == 'cpu'
+    # NOTE: PSpaMM 0.3.0+ supports SIMD-aligned block sparsity in A (which is currently covered by sparseA + alignedA)
+    return self._archSupported() and alignedC and alignedA and (not transA and not transB) and target == 'cpu'
 
   def preference(self, m, n, k, sparseA, sparseB, transA, transB, alpha, beta, alignedA, alignedC):
     if sparseB:
+      return Preference.HIGH
+    if sparseA and alignedA:
       return Preference.HIGH
     if (m*n*k)**(1./3.) <= self._threshold:
       return Preference.HIGH


### PR DESCRIPTION
We update the CPU implementation a bit. In particular:

* Add SIMD-aligned block sparsity support (cf. https://github.com/SeisSol/SeisSol/pull/1243 )
* Update PSpaMM support to 0.3.0 (including a RISC-V V pseudo target)
* Enable prefetching for AVX2/HSW/Zen{1..3} (it _is_ now supported, both by LIBXSMM and PSpaMM)
* Allow the usage of the LIBXSMM generator after 1.17 (`pfsigonly` -> `nopf`)

(we really need something like #60 soon)
