### PR TITLE
Add tensor slicing

### DIFF
--- a/.github/workflows/yateto-ci.yml
+++ b/.github/workflows/yateto-ci.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Codegen Tests
       run: |
         cd ./tests/code-gen
-        for example in matmul minimal indices; do
+        for example in matmul minimal indices slicing; do
           for build_type in Debug Release; do
             for precision in single double; do
               echo " ====== Test Config: ======"

--- a/examples/slicing.py
+++ b/examples/slicing.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from yateto import *
+
+def add(g):
+  M = 32
+  N = 40
+  K = 40
+  A = Tensor('A', (M, K))
+  # B = Tensor('B', (K, N))
+  C = Tensor('C', (M, N))
+
+  XA = Tensor('XA', (32, 32))
+  XB = Tensor('XB', (32, 32))
+  XC = Tensor('XC', (32, 32))
+
+  g.add('slicing1', C['ij'].subslice('j', 4, 36) <= (A['ij']).subslice('j', 8, 40) * (A['ij']).subslice('j', 0, 32))
+  g.add('slicing2', [
+    XC['ij'].subslice('i', i*16, (i+1)*16).subslice('j', j*16, (j+1)*16) <= (XA['ik']).subslice('i', i*16, (i+1)*16) * XB['kj'].subslice('j', j*16, (j+1)*16)
+    for i in range(2) for j in range(2)
+  ])

--- a/tests/code-gen/slicing.py
+++ b/tests/code-gen/slicing.py
@@ -13,8 +13,18 @@ def add(g):
   XB = Tensor('XB', (32, 32))
   XC = Tensor('XC', (32, 32))
 
-  g.add('slicing1', C['ij'].subslice('j', 4, 36) <= (A['ij']).subslice('j', 8, 40) * (A['ij']).subslice('j', 0, 32))
-  g.add('slicing2', [
+  class Counter:
+    def __init__(self):
+      self.counter = 0
+
+  counter = Counter()
+
+  def _(kernel):
+    counter.counter += 1
+    g.add(f'kernel{counter.counter}', kernel)
+
+  _(C['ij'].subslice('j', 4, 36) <= (A['ij']).subslice('j', 8, 40) * (A['ij']).subslice('j', 0, 32))
+  _([
     XC['ij'].subslice('i', i*16, (i+1)*16).subslice('j', j*16, (j+1)*16) <= (XA['ik']).subslice('i', i*16, (i+1)*16) * XB['kj'].subslice('j', j*16, (j+1)*16)
     for i in range(2) for j in range(2)
   ])

--- a/yateto/aspp.py
+++ b/yateto/aspp.py
@@ -68,7 +68,7 @@ class dense(ASpp):
 
   def reshape(self, shape):
     rsh = type(self)(shape)
-    assert rsh.size == self.size
+    assert rsh.size == self.size, f'Size mismatch: {rsh.size} ({rsh.shape}) vs. {self.size} ({self.shape})'
     return rsh
 
   def transposed(self, perm):

--- a/yateto/ast/cost.py
+++ b/yateto/ast/cost.py
@@ -106,7 +106,7 @@ class FusedGemmsBoundingBoxCostEstimator(BoundingBoxCostEstimator):
     right_indices = node.rightTerm().indices
     common_indices = left_indices & right_indices
 
-    if left_indices[0] in common_indices:
+    if len(left_indices) == 0 or left_indices[0] in common_indices:
       # swap terms becase we do not allow
       # tensor product along the leading dimension.
       # In other words, LoG will try to swap terms
@@ -118,6 +118,9 @@ class FusedGemmsBoundingBoxCostEstimator(BoundingBoxCostEstimator):
   def estimate_Product(self, node):
     cost = super().estimate_Product(node)
     left_term, right_term = self._get_terms(node)
+
+    # NOTE: the case rank-0 tensor product rank-0 tensor is currently ill-supported here,
+    # (we only save against _one_ rank-0 tensor in self._get_terms)
 
     bb = self._cache[left_term]
     cost /= bb[self._lead_dim].size()

--- a/yateto/ast/node.py
+++ b/yateto/ast/node.py
@@ -225,7 +225,8 @@ class Op(Node):
 
   def computeMemoryLayout(self):
     alignStride = False
-    alignOffset = 2**64
+    alignOffset = float('inf')
+
     if len(self.indices) > 0:
       for child in self:
         if self.indices[0] in child.indices:
@@ -234,7 +235,7 @@ class Op(Node):
             alignStride = True
             alignOffset = min(alignOffset, child.memoryLayout().alignmentOffset(position))
 
-    # NOTE: the offset is needed for slicing. Since we don't use selector matrices, the alignment might be off.
+    # NOTE: the offset is needed for slicing. Since we don't use selector matrices, the EQSPP alignment might be off.
 
     self._memoryLayout = DenseMemoryLayout.fromSpp(self.eqspp(), alignStride=alignStride, alignOffset=alignOffset)
 

--- a/yateto/ast/node.py
+++ b/yateto/ast/node.py
@@ -216,14 +216,18 @@ class Op(Node):
 
   def computeMemoryLayout(self):
     alignStride = False
+    alignOffset = 2**64
     if len(self.indices) > 0:
       for child in self:
         if self.indices[0] in child.indices:
           position = child.indices.find(self.indices[0])
           if child.memoryLayout().mayVectorizeDim(position):
             alignStride = True
-            break
-    self._memoryLayout = DenseMemoryLayout.fromSpp(self.eqspp(), alignStride=alignStride)
+            alignOffset = min(alignOffset, child.memoryLayout().alignmentOffset(position))
+
+    # NOTE: the offset is needed for slicing. Since we don't use selector matrices, the alignment might be off.
+
+    self._memoryLayout = DenseMemoryLayout.fromSpp(self.eqspp(), alignStride=alignStride, alignOffset=alignOffset)
 
   def fixedIndexPermutation(self):
     return False

--- a/yateto/ast/transformer.py
+++ b/yateto/ast/transformer.py
@@ -2,7 +2,7 @@ import sys
 from copy import deepcopy
 from typing import Union
 from .visitor import Visitor, PrettyPrinter, ComputeSparsityPattern, ComputeIndexSet
-from .node import IndexedTensor, Op, Assign, Einsum, Add, Product, IndexSum, Contraction, ScalarMultiplication, SliceView, SelectView
+from .node import IndexedTensor, Op, Assign, Einsum, Add, Product, IndexSum, Contraction, ScalarMultiplication, SliceView
 from .indices import Indices
 from .log import LoG
 from . import opt
@@ -91,11 +91,6 @@ class DeduceIndices(Transformer):
   def visit_SliceView(self, node, bound):
     self.visit(node.term(), bound)
     node.indices = Indices(node.term().indices, [shape if index != node.index else (node.end - node.start) for index, shape in zip(node.term().indices, node.term().shape())])
-    return node
-  
-  def visit_SelectView(self, node, bound):
-    self.visit(node.term(), bound)
-    node.indices = Indices([index for index in node.term().indices if index != node.index], [shape for index, shape in zip(node.term().indices, node.term().shape()) if index != node.index])
     return node
 
   def visit_Assign(self, node, bound):
@@ -235,11 +230,6 @@ class EquivalentSparsityPattern(Transformer):
     return node
   
   def visit_SliceView(self, node):
-    self.generic_visit(node)
-    node.setEqspp(node.computeSparsityPattern())
-    return node
-  
-  def visit_SelectView(self, node):
     self.generic_visit(node)
     node.setEqspp(node.computeSparsityPattern())
     return node

--- a/yateto/ast/transformer.py
+++ b/yateto/ast/transformer.py
@@ -107,12 +107,16 @@ class DeduceIndices(Transformer):
     lhs = node[0]
     rhs = node[1]
     
-    tlhs = lhs.viewed()
-    if not isinstance(tlhs, IndexedTensor):
+    lhsTensor = lhs.viewed()
+    if not isinstance(lhsTensor, IndexedTensor):
       raise ValueError('Assign: Left-hand side must be of type IndexedTensor')
-    
-    # recurse through all views to get the restricted indices
-    self.visit(lhs, bound=set(tlhs.indices))
+
+    # we cannot get the indices of a view directly; so we need to start at the viewed lhs tensor
+    # (for tensors, we know their final indices before this transform)
+
+    self.visit(lhs, bound=set(lhsTensor.indices))
+
+    # now use the restricted (viewed) index ranges onto the rhs AST
 
     self.visit(rhs, bound=set(lhs.indices))
 

--- a/yateto/ast/transformer.py
+++ b/yateto/ast/transformer.py
@@ -2,7 +2,7 @@ import sys
 from copy import deepcopy
 from typing import Union
 from .visitor import Visitor, PrettyPrinter, ComputeSparsityPattern, ComputeIndexSet
-from .node import IndexedTensor, Op, Assign, Einsum, Add, Product, IndexSum, Contraction, ScalarMultiplication
+from .node import IndexedTensor, Op, Assign, Einsum, Add, Product, IndexSum, Contraction, ScalarMultiplication, SliceView, SelectView
 from .indices import Indices
 from .log import LoG
 from . import opt
@@ -87,13 +87,27 @@ class DeduceIndices(Transformer):
     self.visit(node.term(), bound)
     node.indices = deepcopy(node.term().indices)
     return node
+  
+  def visit_SliceView(self, node, bound):
+    self.visit(node.term(), bound)
+    node.indices = Indices(node.term().indices, [shape if index != node.index else (node.end - node.start) for index, shape in zip(node.term().indices, node.term().shape())])
+    return node
+  
+  def visit_SelectView(self, node, bound):
+    self.visit(node.term(), bound)
+    node.indices = Indices([index for index in node.term().indices if index != node.index], [shape for index, shape in zip(node.term().indices, node.term().shape()) if index != node.index])
+    return node
 
   def visit_Assign(self, node, bound):
     lhs = node[0]
     rhs = node[1]
     
-    if not isinstance(lhs, IndexedTensor):
+    tlhs = lhs.viewed()
+    if not isinstance(tlhs, IndexedTensor):
       raise ValueError('Assign: Left-hand side must be of type IndexedTensor')
+    
+    # recurse through all views to get the restricted indices
+    self.visit(lhs, bound=set(tlhs.indices))
 
     self.visit(rhs, bound=set(lhs.indices))
 
@@ -218,6 +232,16 @@ class EquivalentSparsityPattern(Transformer):
 
     # TODO: Backtracking of equivalent sparsity pattern to children?
 
+    return node
+  
+  def visit_SliceView(self, node):
+    self.generic_visit(node)
+    node.setEqspp(node.computeSparsityPattern())
+    return node
+  
+  def visit_SelectView(self, node):
+    self.generic_visit(node)
+    node.setEqspp(node.computeSparsityPattern())
     return node
 
 class SetSparsityPattern(Transformer):

--- a/yateto/ast/visitor.py
+++ b/yateto/ast/visitor.py
@@ -73,7 +73,10 @@ class FindTensors(Visitor):
     return tensors
 
   def visit_IndexedTensor(self, node):
-    return {node.name(): node.tensor}
+    if node.tensor is not None and node.tensor.temporary:
+      return {}
+    else:
+      return {node.name(): node.tensor}
 
 class FindIndexPermutations(Visitor):
   class Variant(object):

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -43,10 +43,12 @@ class IndexedTensorDescription(TensorDescription):
     values = None
     datatype = None
     addressing = None
-    if hasattr(node, 'tensor'):
-      is_const = node.tensor.is_compute_constant()
+
+    baseNode = node.viewed()
+    if hasattr(baseNode, 'tensor'):
+      is_const = baseNode.tensor.is_compute_constant()
       if is_const:
-        values = node.tensor.values()
+        values = baseNode.tensor.values()
       datatype = None # node.tensor.datatype
       addressing = None # node.tensor.addressing
     return cls(str(var), node.indices, var.memoryLayout(), node.eqspp(), is_const, var.is_temporary, values, datatype, addressing)

--- a/yateto/codegen/gemm/factory.py
+++ b/yateto/codegen/gemm/factory.py
@@ -1,5 +1,4 @@
 from ...ast.indices import BoundingBox, Range
-from ...memory import CSCMemoryLayout
 from ..common import TensorDescription
 from .generic import Generic
 from .gemmgen import GemmGen
@@ -28,8 +27,8 @@ class Description(object):
     self.beta = beta
     self.prefetchName = prefetchName
     
-    self.isACsc = isinstance(self.leftTerm.memoryLayout, CSCMemoryLayout)
-    self.isBCsc = isinstance(self.rightTerm.memoryLayout, CSCMemoryLayout)
+    self.isACsc = self.leftTerm.memoryLayout.isCSC()
+    self.isBCsc = self.rightTerm.memoryLayout.isCSC()
     
     if self.isACsc and self.isBCsc:
       raise RuntimeError('GEMM: sparse x sparse is currently not supported.')

--- a/yateto/codegen/log/generic.py
+++ b/yateto/codegen/log/generic.py
@@ -17,8 +17,6 @@ class Generic(object):
     cpp('{} {}* {} = {}{};'.format(self._arch.typename, 'const' if const else '', targetName, baseName, addressStr))
 
   def _alignedStart(self, term, loopIndices):
-    if len(loopIndices) == 0:
-      return True
     return term.memoryLayout.isAlignedAddressString(term.indices, term.indices & loopIndices)
     
   def _memLayout(self, term, I, J):
@@ -68,8 +66,6 @@ class Generic(object):
     innerBname = '_Bin' if hasInnerLoops else outerBname
     innerCname = '_Cin' if hasInnerLoops else outerCname
     innerPrefetchName = '_Cprefetchin' if hasInnerLoops and outerPrefetchName is not None else outerPrefetchName
-
-    alignedStartA = not hasOuterLoops or self._alignedStart(d.leftTerm, d.outerLoopIndices)
     
     AmemLayout = self._memLayout(d.leftTerm, Im, Ik)
     BmemLayout = self._memLayout(d.rightTerm, Ik, In)

--- a/yateto/codegen/product/factory.py
+++ b/yateto/codegen/product/factory.py
@@ -1,4 +1,3 @@
-from ...memory import CSCMemoryLayout
 from ..common import *
 from .generic import Generic
 
@@ -10,8 +9,8 @@ class Description(object):
     self.leftTerm = leftTerm
     self.rightTerm = rightTerm
 
-    self.isACsc = isinstance(self.leftTerm.memoryLayout, CSCMemoryLayout)
-    self.isBCsc = isinstance(self.rightTerm.memoryLayout, CSCMemoryLayout)
+    self.isACsc = self.leftTerm.memoryLayout.isCSC()
+    self.isBCsc = self.rightTerm.memoryLayout.isCSC()
     
     rA = loopRanges(self.leftTerm, self.result.indices)
     rB = loopRanges(self.rightTerm, self.result.indices)

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -512,7 +512,7 @@ class UnitTestGenerator(KernelGenerator):
             utName=self._name(var),
             viewName=self._viewName(var),
             shape=', '.join([str(s) for s in shape]),
-            start=', '.join(['0']*len(shape))
+            start=', '.join(['0'] * len(shape))
           )
         )
         prefix = '{}::'.format(var.tensor.namespace) if var.tensor.namespace else ''

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -469,7 +469,7 @@ class UnitTestGenerator(KernelGenerator):
 
   @classmethod
   def _name(cls, var):
-    if var.isLocal():
+    if not var.isGlobal():
       return str(var)
     return '_ut_' + cls._tensorName(var)
 

--- a/yateto/controlflow/graph.py
+++ b/yateto/controlflow/graph.py
@@ -46,14 +46,77 @@ class Variable(object):
     return str(self)
   
   def __eq__(self, other):
-    isEq = self.name == other.name
-    assert not isEq or (self.writable == other.writable and self._memoryLayout == other._memoryLayout)
+    isEq = self.name == other.viewed().name # and self._memoryLayout == other._memoryLayout
+    assert not isEq or (self.writable == other.viewed().writable and self._memoryLayout == other.viewed()._memoryLayout)
     return isEq
 
   def setWritable(self, name):
     if self.name == name:
       self.writable = True
+  
+  def viewed(self):
+    return self
 
+class VariableView(object):
+  def __init__(self, variable, memoryLayout, eqspp):
+    self.variable = variable.viewed()
+    self._memoryLayout = memoryLayout
+    self._eqspp = eqspp
+
+  @property
+  def tensor(self):
+    return self.variable.tensor
+  
+  @property
+  def writable(self):
+    return self.variable.writable
+  
+  @property
+  def is_temporary(self):
+    return self.variable.is_temporary
+  
+  def maySubstitute(self, when, by):
+    return self.substituted(when, by).memoryLayout().isCompatible(self.eqspp())
+  
+  def substituted(self, when, by, memoryLayout=None):
+    return by if self == when else self
+
+  def viewed(self):
+    return self.variable
+
+  def variables(self):
+    return {self.variable}
+
+  def resultCompatible(self, result):
+    return result.memoryLayout().isCompatible(self.eqspp())
+
+  def isGlobal(self):
+    return self.variable.isGlobal()
+
+  def isLocal(self):
+    return self.variable.isLocal()
+
+  def memoryLayout(self):
+    return self._memoryLayout
+
+  def eqspp(self):
+    return self._eqspp
+
+  def __hash__(self):
+    return hash(self.variable.name)
+  
+  def __str__(self):
+    return f'{self.variable.name}'
+  
+  def __repr__(self):
+    return str(self)
+  
+  def __eq__(self, other):
+    isEq = self.variable == other.viewed() and self._memoryLayout == other._memoryLayout
+    return isEq
+
+  def setWritable(self, name):
+    self.variable.setWritable(name)
 
 class Expression(object):
   def __init__(self, node, memoryLayout, variables):
@@ -68,7 +131,7 @@ class Expression(object):
     return self.node.eqspp()
 
   def variables(self):
-    return set([var for var in self._variables])
+    return set([var.viewed() for var in self._variables])
 
   def variableList(self):
     return self._variables

--- a/yateto/controlflow/graph.py
+++ b/yateto/controlflow/graph.py
@@ -25,10 +25,10 @@ class Variable(object):
     return result.memoryLayout().isCompatible(self.eqspp())
 
   def isGlobal(self):
-    return self.tensor is not None
+    return self.tensor is not None and not self.tensor.temporary
 
   def isLocal(self):
-    return not self.isGlobal()
+    return not self.isGlobal() and (self.tensor is None or not self.tensor.temporary)
 
   def memoryLayout(self):
     return self._memoryLayout

--- a/yateto/controlflow/transformer.py
+++ b/yateto/controlflow/transformer.py
@@ -134,7 +134,7 @@ class DetermineLocalInitialization(object):
     for i in range(n-1):
       ua = cfg[i].action
       # assign buffer
-      if ua and not ua.isCompound() and ua.result.isLocal():
+      if ua and not ua.isCompound() and not ua.result.isGlobal():
         if ua.result in usedBuffers:
             buf = usedBuffers[ua.result]
         elif len(freeBuffers) > 0:
@@ -145,7 +145,7 @@ class DetermineLocalInitialization(object):
         cfg[i].bufferMap[ua.result] = buf
         usedBuffers[ua.result] = buf
 
-        size = ua.result.memoryLayout().requiredReals()
+        size = ua.result.viewed().memoryLayout().requiredReals()
         if buf in bufferSize:
           bufferSize[buf] = max(bufferSize[buf], size)
         else:

--- a/yateto/controlflow/transformer.py
+++ b/yateto/controlflow/transformer.py
@@ -154,8 +154,11 @@ class DetermineLocalInitialization(object):
       # free buffers
       free = cfg[i].live - cfg[i+1].live
       for local in free:
-        if local in usedBuffers:
-          freeBuffers.appendleft(usedBuffers.pop(local))
+        # warning: local.isLocal() check is suboptimal (but currently good enough)
+        # refactor liveness for better results
+        if local.isLocal():
+          if local in usedBuffers:
+            freeBuffers.appendleft(usedBuffers.pop(local))
 
     if len(cfg) > 0:
       cfg[0].initBuffer = bufferSize

--- a/yateto/controlflow/transformer.py
+++ b/yateto/controlflow/transformer.py
@@ -145,7 +145,7 @@ class DetermineLocalInitialization(object):
         cfg[i].bufferMap[ua.result] = buf
         usedBuffers[ua.result] = buf
 
-        size = ua.result.viewed().memoryLayout().requiredReals()
+        size = ua.result.viewed().memoryLayout().storage().requiredReals()
         if buf in bufferSize:
           bufferSize[buf] = max(bufferSize[buf], size)
         else:

--- a/yateto/controlflow/visitor.py
+++ b/yateto/controlflow/visitor.py
@@ -40,6 +40,16 @@ class AST2ControlFlow(Visitor):
     
     return result
   
+  def visit_SliceView(self, node):
+    var = self.visit(node.term())
+    ml = node.getMemoryLayout(var.memoryLayout())
+    return VariableView(var, ml, node.eqspp())
+
+  def visit_SelectView(self, node):
+    var = self.visit(node.term())
+    ml = node.getMemoryLayout(var.memoryLayout())
+    return VariableView(var, ml, node.eqspp())
+
   def visit_Add(self, node):
     variables = [self.visit(child) for child in node]
     assert len(variables) > 1

--- a/yateto/controlflow/visitor.py
+++ b/yateto/controlflow/visitor.py
@@ -45,11 +45,6 @@ class AST2ControlFlow(Visitor):
     ml = node.getMemoryLayout(var.memoryLayout())
     return VariableView(var, ml, node.eqspp())
 
-  def visit_SelectView(self, node):
-    var = self.visit(node.term())
-    ml = node.getMemoryLayout(var.memoryLayout())
-    return VariableView(var, ml, node.eqspp())
-
   def visit_Add(self, node):
     variables = [self.visit(child) for child in node]
     assert len(variables) > 1

--- a/yateto/controlflow/visitor.py
+++ b/yateto/controlflow/visitor.py
@@ -81,13 +81,13 @@ class AST2ControlFlow(Visitor):
     return variables[0]
   
   def visit_IndexedTensor(self, node):
-    return Variable(node.name(), node.name() in self._writable, self._ml(node), node.eqspp(), node.tensor)
-  
+    return Variable(node.name(), node.name() in self._writable, self._ml(node), node.eqspp(), node.tensor, is_temporary=node.tensor.temporary)
+
   def _addAction(self, action):
     self._cfg.append(ProgramPoint(action))
 
   def _nextTemporary(self, node):
-    name = '{}{}'.format(self.TEMPORARY_RESULT, self._tmp)
+    name = f'{self.TEMPORARY_RESULT}{self._tmp}'
     self._tmp += 1
     return Variable(name, True, self._ml(node), node.eqspp(), is_temporary=True)
 

--- a/yateto/gemm_configuration.py
+++ b/yateto/gemm_configuration.py
@@ -215,7 +215,10 @@ class PSpaMM(CodeGenerator):
   def supported(self, m, n, k, sparseA, sparseB, transA, transB, alpha,
                 beta, alignedA, alignedC, target):
     # NOTE: PSpaMM 0.3.0+ supports SIMD-aligned block sparsity in A (which is currently covered by sparseA + alignedA)
-    return self.archSupported() and alignedC and alignedA and (not transA and not transB) and target == 'cpu'
+    # also, it supports for AVX512/10 and SVE unaligned matmuls in 0.3.1
+    noAlign = self._arch.host_name.lower() in {'thunderx2t99', 'knl', 'skx', 'a64fx', 'bergamo', 'turin', 'sve128', 'sve256', 'sve512', 'sve1024', 'sve2048', 'avx10-128', 'avx10-256', 'avx10-512'}
+    alignment = sparseA and alignedA or not sparseA and (noAlign or alignedA)
+    return self.archSupported() and (alignedC or noAlign) and alignment and (not transA and not transB) and target == 'cpu'
 
   def preference(self, m, n, k, sparseA, sparseB, transA, transB, alpha, beta, alignedA, alignedC):
     if sparseB:

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -271,10 +271,6 @@ class DenseMemoryLayout(MemoryLayout):
   
   def spp(self):
     raise NotImplementedError()
-    #subslice = tuple(slice(d.start, d.end) if d in self._bbox)
-    #superarray = np.zeros(tuple(self._stride), dtype=bool)
-    #superarray[subslice] = spp.as_ndarray()
-    #return aspp.general(superarray)
   
   def storage(self):
     return self
@@ -470,9 +466,10 @@ class MemoryLayoutView(MemoryLayout):
     raise NotImplementedError()
   
   def isCompatible(self, spp):
-    # not 100%ly sure; but prevents errors in the method below
+    # only a rough criterion. Can possibly be refined.
     if spp.as_ndarray().shape != tuple(self.shape()):
       return False
+
     return self.base.isCompatible(self.relspp(spp))
 
   def mayVectorizeDim(self, dim):

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -266,6 +266,7 @@ class DenseMemoryLayout(MemoryLayout):
   def subslice(self, index, start, end):
     newshape = tuple(end - start if i == index else self._shape[i] for i in range(len(self._shape)))
     newbbox = BoundingBox([Range(max(self._bbox[i].start, start) - start, min(self._bbox[i].stop, end) - start) if i == index else self._bbox[i] for i in range(len(self._shape))])
+    #newbbox = self._bbox
     newoffset = [start if i == index else self._offset[i] for i in range(len(self._shape))]
     return DenseMemoryLayout(newshape, boundingBox=newbbox, stride=self._stride, offset=newoffset)
 
@@ -273,7 +274,7 @@ class DenseMemoryLayout(MemoryLayout):
     return self._stride == other._stride and self._bbox == other._bbox and self._stride == other._stride and self._offset == other._offset
 
   def __str__(self):
-    return '{}(shape: {}, bounding box: {}, stride: {}, offset:)'.format(type(self).__name__, self._shape, self._bbox, self._stride, self._offset)
+    return '{}(shape: {}, bounding box: {}, stride: {}, offset: {})'.format(type(self).__name__, self._shape, self._bbox, self._stride, self._offset)
 
 class CSCMemoryLayout(MemoryLayout):
   def __init__(self, spp, alignStride=False, bbox=None):
@@ -335,6 +336,12 @@ class CSCMemoryLayout(MemoryLayout):
   
   def colPointer(self):
     return self._colPtr
+  
+  def isAlignedAddressString(self, indices, I = None):
+    if I is None:
+      I = set(indices)
+    positions = indices.positions(I)
+    return len(positions) == 0 or (positions[0] == 0 and all(p != 0 for p in positions[1:]))
   
   def address(self, entry):
     assert entry in self._bbox

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -470,6 +470,9 @@ class MemoryLayoutView(MemoryLayout):
     raise NotImplementedError()
   
   def isCompatible(self, spp):
+    # not 100%ly sure; but prevents errors in the method below
+    if spp.as_ndarray().shape != tuple(self.shape()):
+      return False
     return self.base.isCompatible(self.relspp(spp))
 
   def mayVectorizeDim(self, dim):

--- a/yateto/type.py
+++ b/yateto/type.py
@@ -83,7 +83,8 @@ class Tensor(IdentifiedType):
                spp=None,
                memoryLayoutClass=DenseMemoryLayout,
                alignStride=False,
-               namespace=None):
+               namespace=None,
+               temporary=False):
     super().__init__(name, namespace=namespace)
     if not isinstance(shape, tuple):
       raise ValueError('shape must be a tuple')
@@ -97,6 +98,8 @@ class Tensor(IdentifiedType):
     self._name = name
     self._shape = shape
     self._values = None
+
+    self.temporary = temporary
 
     if namespace is None:
       self.namespace = ''


### PR DESCRIPTION
Usage:

`tensor['ijk'].subslice('i', start, end).subslice('j', start, end)`

Also works on arbitrary expressions (not just tensors); if you know the right index for it.

Also includes support for named temporary tensors (not really necessary on the CPU side of things; but for the GPU kernels mostly)
