### PR TITLE
Backwards compatibility to Python 3.7

### DIFF
--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .. import aspp
 from ..ast.indices import BoundingBox
 from ..ast.log import splitByDistance

--- a/yateto/codegen/tiny_tensor_language.py
+++ b/yateto/codegen/tiny_tensor_language.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 from enum import Enum
 from abc import ABC, abstractmethod
 from typing import Optional, Union, List


### PR DESCRIPTION
Add future imports as an ad hoc backwards compatibility thing.

Alas, Python 3.7 or the likes (even 3.6) is still present as default on some systems—or the software stack is outdated.
