### PR TITLE
Add const access operators, and some missing headers

### DIFF
--- a/include/yateto/InitTools.h
+++ b/include/yateto/InitTools.h
@@ -3,13 +3,8 @@
 
 #include "CopyPolicy.h"
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
-
-/*
-#ifdef ACL_DEVICE
-#include "device.h"
-#endif
-*/
 
 namespace yateto {
     /** Computes a number of tensors inside of a tensor family.

--- a/include/yateto/LinearAllocator.h
+++ b/include/yateto/LinearAllocator.h
@@ -1,7 +1,8 @@
 #ifndef YATETO_LINEAR_ALLOCATED_H_
 #define YATETO_LINEAR_ALLOCATED_H_
 
-#include <assert.h>
+#include <cassert>
+#include <cstddef>
 
 namespace yateto {
 template<typename T>

--- a/include/yateto/Misc.h
+++ b/include/yateto/Misc.h
@@ -1,6 +1,8 @@
 #ifndef YATETO_MISC_H_
 #define YATETO_MISC_H_
 
+#include <cstddef>
+
 namespace yateto {
 
 template<typename KernelType>


### PR DESCRIPTION
We add `const` operators for access. Thus eliminating some `clang-tidy` problems in SeisSol.

Besides, some headers get included.
