### PR TITLE
Add support for external kernel code generators

### DIFF
--- a/yateto/codegen/cache.py
+++ b/yateto/codegen/cache.py
@@ -3,10 +3,16 @@ from .code import Cpp
 class RoutineGenerator(object):
   def __call__(self, routineName, fileName):
     pass
+  
+  def target(self):
+    return 'cpu'
 
 class GpuRoutineGenerator(object):
   def __call__(self, routineName, fileName):
     pass
+  
+  def target(self):
+    return 'gpu'
 
 class RoutineCache(object):
   def __init__(self):
@@ -27,16 +33,20 @@ class RoutineCache(object):
     with Cpp(gpuFileName) as gpucpp:
       with Cpp(cppFileName) as cpp:
         for generator in self._generators.values():
-          if isinstance(generator, GpuRoutineGenerator):
+          if generator.target() == 'gpu':
             generator.header(gpucpp)
-          else:
+          elif generator.target() == 'cpu':
             generator.header(cpp)
+          else:
+            raise NotImplementedError(f'Unknown target: {generator.target()}')
 
     for name, generator in self._routines.items():
-      if isinstance(generator, GpuRoutineGenerator):
+      if generator.target() == 'gpu':
         declaration = generator(name, gpuFileName)
-      else:
+      elif generator.target() == 'cpu':
         declaration = generator(name, cppFileName)
+      else:
+        raise NotImplementedError(f'Unknown target: {generator.target()}')
       header(declaration)
 
 class TinytcWriter(GpuRoutineGenerator):

--- a/yateto/codegen/common.py
+++ b/yateto/codegen/common.py
@@ -34,7 +34,7 @@ class TensorDescription(object):
 
 class IndexedTensorDescription(TensorDescription):
   def __init__(self, name, indices, memoryLayout, eqspp, is_compute_constant=False, is_temporary=False, values=None, datatype=None, addressing=None):
-    super().__init__(name, memoryLayout, eqspp, is_compute_constant, is_temporary)
+    super().__init__(name, memoryLayout, eqspp, is_compute_constant, is_temporary, values, datatype, addressing)
     self.indices = indices
 
   @classmethod

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -309,7 +309,7 @@ class ExportFactory(KernelFactory):
     term = arguments[0]
     return self.handleLinear(IndexedTensorDescription(str(result), node.indices, result.memoryLayout(), result.eqspp()), [IndexedTensorDescription(str(term), node.term().indices, term.memoryLayout(), term.eqspp())], add, scalar, False, False)
   
-  def simple(self, result, term, add, scalar, routineCache):
+  def simple(self, result, term, add, scalar, routineCache, gemm_cfg):
     return self.handleLinear(IndexedTensorDescription(str(result), self._indices(result), result.memoryLayout(), result.eqspp()), [IndexedTensorDescription(str(term), self._indices(term), term.memoryLayout(), term.eqspp())], add, scalar, False, False)
 
   def getIndices(self, dest, ops):

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -276,13 +276,16 @@ class ExportGenerator:
   def generate(self, cpp, cache):
     pass
   
-  def add_operation(self, dest, ops, target, permute, add):
+  def add_linear_operation(self, dest, ops, target, permute, add):
     pass
 
+def exportFactoryCreator(generator):
+  return lambda cpp, arch, target: ExportFactory(generator(arch), cpp, arch, target)
+
 class ExportFactory(KernelFactory):
-  def __init__(self, cpp, arch, target):
+  def __init__(self, generator, cpp, arch, target):
     super().__init__(cpp, arch, target)
-    self.generator = GpuKernelGenerator(arch)
+    self.generator = generator
   
   def post_generate(self, routine_cache):
     self.generator.generate(self._cpp, routine_cache)
@@ -339,4 +342,4 @@ class ExportFactory(KernelFactory):
       target += [[]]
       permute += [[]]
     
-    return self.generator.add_operation(dest, ops, target, permute, add)
+    return self.generator.add_linear_operation(dest, ops, target, permute, add)

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -89,7 +89,7 @@ class KernelFactory(object):
     shape = var.memoryLayout().shape()
     return Indices(string.ascii_lowercase[:len(shape)], shape)
 
-class OptimisedKernelFactory(KernelFactory):
+class OptimizedKernelFactory(KernelFactory):
   def __init__(self, cpp, arch, target):
     super().__init__(cpp, arch, target)
 

--- a/yateto/codegen/factory.py
+++ b/yateto/codegen/factory.py
@@ -268,6 +268,8 @@ class UnitTestFactory(KernelFactory):
     self._rand += 1
 
 class ExportGenerator:
+  INTERFACE_VERSION = 1
+
   def __init__(self, arch):
     self.arch = arch
   

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -96,7 +96,7 @@ class KernelGenerator(object):
           hwFlops += factory.simple(action.result, action.term, action.add, scalar, routineCache, gemm_cfg)
     return hwFlops, required_tmp_mem
 
-class OptimisedKernelGenerator(KernelGenerator):
+class OptimizedKernelGenerator(KernelGenerator):
   NAMESPACE = 'kernel'
   EXECUTE_NAME = 'execute'
   FIND_EXECUTE_NAME = 'findExecute'
@@ -177,7 +177,7 @@ class OptimisedKernelGenerator(KernelGenerator):
     functionIO = StringIO()
     function = ''
     with Cpp(functionIO) as fcpp:
-      factory = OptimisedKernelFactory(fcpp, self._arch, target)
+      factory = OptimizedKernelFactory(fcpp, self._arch, target)
       hwFlops, tmp_memory = super().generate(fcpp, cfg, factory, self._routineCache, gemm_cfg)
       factory.freeTmp()
       factory.reset_stream()
@@ -536,7 +536,7 @@ class UnitTestGenerator(KernelGenerator):
         cpp.emptyline()
 
 
-      cpp( '{}{}::{} {};'.format(kernel_prefix, OptimisedKernelGenerator.NAMESPACE, kernelClass, self.KERNEL_VAR) )
+      cpp( '{}{}::{} {};'.format(kernel_prefix, OptimizedKernelGenerator.NAMESPACE, kernelClass, self.KERNEL_VAR) )
       for var in scalars:
         cpp( '{}.{}{} = {};'.format(self.KERNEL_VAR, var.baseName(), self._groupIndex(var), self._tensorNameS(var)) )
       for var in variables:
@@ -547,7 +547,7 @@ class UnitTestGenerator(KernelGenerator):
         cpp( f'{self.KERNEL_VAR}.linearAllocator.initialize({self.TMP_MEM});' )
         cpp( f'{self.KERNEL_VAR}.streamPtr = &{self.QUEUE};' )
 
-      cpp( '{}.{}();'.format(self.KERNEL_VAR, OptimisedKernelGenerator.EXECUTE_NAME + (str(index) if index is not None else '')) )
+      cpp( '{}.{}();'.format(self.KERNEL_VAR, OptimizedKernelGenerator.EXECUTE_NAME + (str(index) if index is not None else '')) )
       cpp.emptyline()
 
       if device_test:

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -121,7 +121,7 @@ class OptimizedKernelGenerator(KernelGenerator):
     }
 
     for entry in routine_exporters:
-      self._routine_factories[entry] = ExportFactory(routine_exporters[entry])
+      self._routine_factories[entry] = exportFactoryCreator(routine_exporters[entry])
   
   class KernelOutline(object):
     def __init__(self,

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -188,7 +188,7 @@ class OptimizedKernelGenerator(KernelGenerator):
     functionIO = StringIO()
     function = ''
     with Cpp(functionIO) as fcpp:
-      self._routine_factories[target](fcpp, self._arch, target)
+      factory = self._routine_factories[target](fcpp, self._arch, target)
       hwFlops, tmp_memory = super().generate(fcpp, cfg, factory, self._routineCache, gemm_cfg)
       factory.post_generate(self._routineCache)
       factory.freeTmp()

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -121,7 +121,7 @@ class OptimizedKernelGenerator(KernelGenerator):
     }
 
     for entry in routine_exporters:
-      self._routine_factories[entry] = exportFactoryCreator(routine_exporters[entry])
+      self._routine_factories[entry] = ExportFactory.makeFactory(routine_exporters[entry])
   
   class KernelOutline(object):
     def __init__(self,

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -14,11 +14,10 @@ from .codegen.test_framework import *
 from .codegen.visitor import *
 from .controlflow.visitor import AST2ControlFlow
 from .controlflow.transformer import *
-from .gemm_configuration import GeneratorCollection, DefaultGeneratorCollection, BLASlike, tinytc
+from .gemm_configuration import GeneratorCollection, DefaultGeneratorCollection, BLASlike, tinytc, GemmForge
 from typing import List
 from io import StringIO
 import importlib.util
-chainforge_spec = importlib.util.find_spec('chainforge')
 
 
 class Kernel(object):
@@ -293,8 +292,11 @@ class Generator(object):
     if not gemm_cfg:
       gemm_cfg = DefaultGeneratorCollection(self._arch)
 
+    hasGemmforge = any([isinstance(tool, GemmForge) for tool in gemm_cfg.gemmTools])
     hasTinytc = any([isinstance(tool, tinytc) for tool in gemm_cfg.gemmTools])
-    enableFusedGemm = bool(chainforge_spec) or hasTinytc
+
+    chainforge_spec = importlib.util.find_spec('chainforge')
+    enableFusedGemm = (hasGemmforge and bool(chainforge_spec)) or hasTinytc
 
     print('Deducing indices...')
     for kernel in self._kernels:

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -324,7 +324,7 @@ class Generator(object):
 
     print('Generating kernels...')
     cache = RoutineCache()
-    optKernelGenerator = OptimisedKernelGenerator(self._arch, cache)
+    optKernelGenerator = OptimizedKernelGenerator(self._arch, cache)
 
     kernelSource = StringIO()
     kernelSourceContent = ''

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -263,7 +263,9 @@ class Generator(object):
                namespace='yateto',
                gemm_cfg: GeneratorCollection = None,
                cost_estimator=BoundingBoxCostEstimator,
-               include_tensors=set()):
+               include_tensors=set(),
+               routine_exporters={}
+               ):
 
     if not gemm_cfg:
       gemm_cfg = DefaultGeneratorCollection(self._arch)
@@ -324,7 +326,7 @@ class Generator(object):
 
     print('Generating kernels...')
     cache = RoutineCache()
-    optKernelGenerator = OptimizedKernelGenerator(self._arch, cache)
+    optKernelGenerator = OptimizedKernelGenerator(self._arch, cache, routine_exporters)
 
     kernelSource = StringIO()
     kernelSourceContent = ''

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -294,6 +294,9 @@ class CSCMemoryLayout(MemoryLayout):
   def requiredReals(self):
     return len(self._rowIndex)
 
+  def bbox(self):
+    return self._bbox
+
   def bboxi(self, dim):
     return self._bbox[dim]
   

--- a/yateto/type.py
+++ b/yateto/type.py
@@ -24,6 +24,8 @@ class IdentifiedType(AbstractType):
     
     self._name = name
     self.namespace = namespace
+
+    self.datatype = None # TODO
   
   def __str__(self):
     return self._name


### PR DESCRIPTION
Add a minimalistic interface for external kernel code generation modules (which differ from pure-GEMM/fused-GEMM kernel code generators in their scope).

The more advanced datatype+addressing forwarding to the backend will be done by a future PR.
