### PR TITLE
Add Support for Block-Level GPU Kernels

### DIFF
--- a/yateto/codegen/copyscaleadd/factory.py
+++ b/yateto/codegen/copyscaleadd/factory.py
@@ -42,4 +42,4 @@ def generator(arch, descr, gemm_cfg, target):
           return CopyScaleAddGenerator(arch, descr)
       else:
           raise NotImplementedError(f'no implementation found for {target} target')
-  return Generic(arch, descr)
+  return Generic(arch, descr, target)

--- a/yateto/codegen/copyscaleadd/generic.py
+++ b/yateto/codegen/copyscaleadd/generic.py
@@ -1,9 +1,10 @@
 from ..common import *
 
 class Generic(object):
-  def __init__(self, arch, descr):
+  def __init__(self, arch, descr, target):
     self._arch = arch
     self._descr = descr
+    self._target = target
   
   def _formatTerm(self, alpha, term):
     prefix = ''
@@ -42,4 +43,5 @@ class Generic(object):
 
         return flop
 
-    return forLoops(cpp, d.result.indices, d.loopRanges, CopyScaleAddBody())
+    indexer = self._arch.indexing() if self._target == 'igpu' else None
+    return forLoops(cpp, d.result.indices, d.loopRanges, CopyScaleAddBody(), indexer=indexer)

--- a/yateto/codegen/gemm/factory.py
+++ b/yateto/codegen/gemm/factory.py
@@ -88,4 +88,4 @@ def generator(arch, descr, gemm_cfg, target):
                                     target)
     if gemmTool:
       return GemmGen(arch, descr, gemmTool)
-  return Generic(arch, descr)
+  return Generic(arch, descr, target)

--- a/yateto/codegen/indexsum/factory.py
+++ b/yateto/codegen/indexsum/factory.py
@@ -21,7 +21,7 @@ class Description(object):
     
 
 def generator(arch, descr, target):
-  if target == 'cpu':
+  if target in ['cpu', 'igpu']:
     return Generic(arch, descr)
   elif target == 'gpu':
     raise RuntimeError("IndexSum operation has not been implemented for GPU-like architectures")

--- a/yateto/codegen/indexsum/generic.py
+++ b/yateto/codegen/indexsum/generic.py
@@ -1,9 +1,10 @@
 from ..common import *
 
 class Generic(object):
-  def __init__(self, arch, descr):
+  def __init__(self, arch, descr, target):
     self._arch = arch
     self._descr = descr
+    self._target = target
 
   def generate(self, cpp, routineCache):
     d = self._descr
@@ -27,4 +28,5 @@ class Generic(object):
         flop = 1 if d.alpha != 1.0 else 0
         return d.sumLoopRange.size() + flop
 
-    return forLoops(cpp, d.result.indices, d.loopRanges, IndexSumBody())
+    indexer = self._arch.indexing() if self._target == 'igpu' else None
+    return forLoops(cpp, d.result.indices, d.loopRanges, IndexSumBody(), indexer=indexer)

--- a/yateto/codegen/product/factory.py
+++ b/yateto/codegen/product/factory.py
@@ -25,8 +25,8 @@ class Description(object):
     self.loopRanges = rA    
 
 def generator(arch, descr, target):
-  if target == 'cpu':
-    return Generic(arch, descr)
+  if target in ['cpu', 'igpu']:
+    return Generic(arch, descr, target)
   elif target == 'gpu':
     raise RuntimeError("Product operation has not been implemented for GPU-like architectures")
 

--- a/yateto/codegen/product/generic.py
+++ b/yateto/codegen/product/generic.py
@@ -1,9 +1,10 @@
 from ..common import *
 
 class Generic(object):
-  def __init__(self, arch, descr):
+  def __init__(self, arch, descr, target):
     self._arch = arch
     self._descr = descr
+    self._target = target
 
   def _mult(self, alpha):
     return '{} * '.format(alpha) if alpha != 1.0 else ''
@@ -36,7 +37,8 @@ class Generic(object):
         )
         return self._flop(d.add, d.alpha)
 
-    return forLoops(cpp, d.result.indices, d.loopRanges, ProductBody())
+    indexer = self._arch.indexing() if self._target == 'igpu' else None
+    return forLoops(cpp, d.result.indices, d.loopRanges, ProductBody(), indexer=indexer)
 
   def _generateSparseDense(self, cpp):
     raise NotImplementedError

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -24,7 +24,7 @@ chainforge_spec = importlib.util.find_spec('chainforge')
 class Kernel(object):
   BASE_NAME = r'[a-zA-Z]\w*'
   VALID_NAME = r'^{}$'.format(BASE_NAME)
-  VALID_TARGETS = ['cpu', 'gpu']
+  VALID_TARGETS = ['cpu', 'gpu', 'igpu']
 
   def __init__(self, name, ast, prefetch=None, namespace=None, target='cpu'):
     self.name = name
@@ -367,6 +367,10 @@ class Generator(object):
           header.includeSys('limits')
           header.include('yateto.h')
           header.include(fTensors.hName)
+
+          for path in self._arch.headers():
+            header.includeSys(path)
+
           cpp.include(fKernels.hName)
           with cpp.Namespace(namespace), header.Namespace(namespace):
               # Group kernels by namespace


### PR DESCRIPTION
We

* add GPU block-level kernel support; i.e. called from GPU code, and run in the GPU block. (for now, it's the kernel target `igpu`; instead of `gpu` or `cpu`)
  * That contrasts to the current, kernel-level kernel generation the GPU which is called from host/CPU code.
  * Temporary memory is currently allocated as shared—and needs to be supplied from outside. (TODO for the future: maybe also store some intermediate results in registers) Though effectively, only a pointer is passed.
* make Yateto kernels compile and run with and callable within CUDA device code; also add support (still untested) for HIP, SYCL, and OMP Target as well.

All still very WIP and probably pretty slow, and hence a draft. (the only "performance" benefits at the very moment are that multiple threads are used for some computations; and shared memory is used for intermediate results)
