### PR TITLE
Enable reading compressed matrix files

### DIFF
--- a/yateto/input.py
+++ b/yateto/input.py
@@ -5,6 +5,8 @@ from . import Collection, Tensor
 from .memory import AlignedCSCMemoryLayout, CSCMemoryLayout, DenseMemoryLayout
 from . import aspp
 from .util import create_collection
+import os
+import lzma
 
 import importlib.util
 lxmlSpec = importlib.util.find_spec('lxml')
@@ -70,9 +72,17 @@ def __processMatrix(name, shape, entries, clones, transpose, alignStride, namesp
 def __complain(child):
   raise ValueError('Unknown tag ' + child.tag)
 
+def openMaybeCompressed(basefilename):
+  if os.path.exists(basefilename):
+    return open(basefilename)
+  elif os.path.exists(basefilename + '.xz'):
+    return lzma.open(basefilename + '.xz')
+  else:
+    raise FileNotFoundError(basefilename)
+
 def parseXMLMatrixFile(xmlFile, clones=dict(), transpose=lambda name: False, alignStride=lambda name: False, namespace=None):
-  tree = etree.parse(xmlFile)
-  root = tree.getroot()
+  with openMaybeCompressed(xmlFile) as file:
+    root = etree.fromstring(file.read())
   
   matrices = dict()
   
@@ -101,7 +111,7 @@ def parseXMLMatrixFile(xmlFile, clones=dict(), transpose=lambda name: False, ali
 def parseJSONMatrixFile(jsonFile, clones=dict(), transpose=lambda name: False, alignStride=lambda name: False, namespace=None):
   matrices = dict()
 
-  with open(jsonFile) as j:
+  with openMaybeCompressed(jsonFile) as j:
     content = json.load(j)
     for m in content:
       entries = m['entries']
@@ -119,8 +129,9 @@ def parseJSONMatrixFile(jsonFile, clones=dict(), transpose=lambda name: False, a
   return create_collection(matrices)
 
 def memoryLayoutFromFile(xmlFile, db, clones, strict=False):
-  tree = etree.parse(xmlFile)
-  root = tree.getroot()
+  with openMaybeCompressed(xmlFile) as file:
+    root = etree.fromstring(file.read())
+  
   strtobool = ['yes', 'true', '1']
   groups = dict()
 


### PR DESCRIPTION
Searches for `${FILE}.xz` , if `$FILE` wasn't found, and decompresses it if needed.
