### PR TITLE
Fix two optimizer-related bugs

### DIFF
--- a/yateto/controlflow/transformer.py
+++ b/yateto/controlflow/transformer.py
@@ -34,7 +34,14 @@ class SubstituteForward(object):
     for i in range(n):
       ua = cfg[i].action
       v = cfg[i+1]
-      if not ua.isCompound() and ua.isRHSVariable() and ua.term.writable and ua.result.isLocal() and ua.term not in v.live:
+      
+      if not ua.isCompound() \
+          and ua.isRHSVariable() \
+          and ua.term.writable \
+          and ua.result.isLocal() \
+          and ua.term not in v.live \
+          and (ua.hasTrivialScalar() or ua.term.isLocal()):
+
         when = ua.result
         by = ua.term
         maySubs = all([cfg[j].action.maySubstitute(when, by) for j in range(i, n)])
@@ -42,6 +49,7 @@ class SubstituteForward(object):
           for j in range(i, n):
             cfg[j].action = cfg[j].action.substituted(when, by)
           cfg = LivenessAnalysis().visit(cfg)
+  
     return cfg
 
 class SubstituteBackward(object):

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -347,7 +347,7 @@ class CSCMemoryLayout(MemoryLayout):
     comp = self.fromSpp(spp, alignStride=self.aligned)
 
     bboxOk = comp._bbox in self._bbox
-    sppOk = comp.entries(comp._bbox[0], comp._bbox[1]) == self.entries(comp._bbox[0], comp._bbox[1])
+    sppOk = set(comp.entries(comp._bbox[0], comp._bbox[1])).issubset(set(self.entries(comp._bbox[0], comp._bbox[1])))
 
     # TODO: also check CSC compatibility?
     # rowIndexOk = np.array_equal(self._rowIndex[:len(comp._rowIndex)], comp._rowIndex)

--- a/yateto/memory.py
+++ b/yateto/memory.py
@@ -247,16 +247,16 @@ class DenseMemoryLayout(MemoryLayout):
     return '{}(shape: {}, bounding box: {}, stride: {})'.format(type(self).__name__, self._shape, self._bbox, self._stride)
 
 class CSCMemoryLayout(MemoryLayout):
-  def __init__(self, spp, aligned=False):
+  def __init__(self, spp, alignStride=False):
     super().__init__(spp.shape)
 
-    self.aligned = aligned
+    self.aligned = alignStride
     
     if len(self._shape) != 2:
       raise ValueError('CSCMemoryLayout may only be used for matrices.')
 
     self._bbox = BoundingBox.fromSpp(spp)
-    if aligned:
+    if self.aligned:
       range0 = self._bbox[0]
       rnew = Range( DenseMemoryLayout.ALIGNMENT_ARCH.alignedLower(range0.start), DenseMemoryLayout.ALIGNMENT_ARCH.alignedUpper(range0.stop) )
       self._bbox = BoundingBox([rnew] + self._bbox[1:])
@@ -264,7 +264,7 @@ class CSCMemoryLayout(MemoryLayout):
     nonzeros = spp.nonzero()
     nonzeros = sorted(zip(nonzeros[0], nonzeros[1]), key=lambda x: (x[1], x[0]))
 
-    if aligned:
+    if self.aligned:
       nonzeros_pre = set(nonzeros)
       for nonzero in nonzeros:
         lower = DenseMemoryLayout.ALIGNMENT_ARCH.alignedLower(nonzero[0])
@@ -338,13 +338,22 @@ class CSCMemoryLayout(MemoryLayout):
 
   @classmethod
   def fromSpp(cls, spp, **kwargs):
-    return CSCMemoryLayout(spp)
+    return CSCMemoryLayout(spp, **kwargs)
 
   def __contains__(self, entry):
     return entry in self._bbox
 
   def isCompatible(self, spp):
-    return self.fromSpp(spp) == self
+    comp = self.fromSpp(spp, alignStride=self.aligned)
+
+    bboxOk = comp._bbox in self._bbox
+    sppOk = comp.entries(comp._bbox[0], comp._bbox[1]) == self.entries(comp._bbox[0], comp._bbox[1])
+
+    # TODO: also check CSC compatibility?
+    # rowIndexOk = np.array_equal(self._rowIndex[:len(comp._rowIndex)], comp._rowIndex)
+    # colPtrOk = np.array_equal(self._colPtr[comp._bbox[1].start:comp._bbox[1].stop], comp._colPtr[comp._bbox[1].start:comp._bbox[1].stop])
+
+    return bboxOk and sppOk
 
   def __eq__(self, other):
     return self._bbox == other._bbox and np.array_equal(self._rowIndex, other._rowIndex) and np.array_equal(self._colPtr, other._colPtr)
@@ -352,4 +361,4 @@ class CSCMemoryLayout(MemoryLayout):
 class AlignedCSCMemoryLayout:
   @classmethod
   def fromSpp(cls, spp, **kwargs):
-    return CSCMemoryLayout(spp, aligned=True)
+    return CSCMemoryLayout(spp, alignStride=True)


### PR DESCRIPTION
Fix two bugs:

* sparsity pattern compatibility has been improved for sparse/block sparse matrices—instead of looking for an identical sparsity pattern, we now also allow a subsection of it; thus the backwards substitution now works on these cases. In addition to that, it seems that there were errors in the SeisSol unit tests without this change (and suboptimal backwards substitution) with a chance of them happening as soon as e.g. a sparse `kDivMT` or `kDivM` was involved. (as e.g. present in SeisSol right now everywhere; or before 1.3.1 etc. presumably also for fused simulations back then) That even happened with all GEMM generators disabled.
* forward substitution with a non-trivial scalar, if we have a global variable on the right-hand side (otherwise, we'd replace it with a scaled version of itself)

Not 100%ly sure if the sparse submatrix detection is _really_ correct (w.r.t. CSC); however the tests now seem to pass in SeisSol at least.
