### PR TITLE
Generalize the GPU tests to other backends

### DIFF
--- a/yateto/arch.py
+++ b/yateto/arch.py
@@ -112,6 +112,13 @@ class Architecture(object):
   def __eq__(self, other):
     return self.name == other.name
 
+  def headers(self):
+    if self.backend in ['cpp', 'cuda']:
+      return []
+    elif self.backend in ['hip']:
+      return ['hip/hip_runtime.h']
+    elif self.backend in ['oneapi', 'hipsycl', 'acpp']:
+      return ['sycl/sycl.hpp']
 
 def _get_name_and_precision(ident):
   return ident[1:], ident[0].upper()

--- a/yateto/codegen/test_framework.py
+++ b/yateto/codegen/test_framework.py
@@ -30,8 +30,8 @@ class TestFramework(ABC):
         cpp.include(kernelsInclude)
         cpp.include(initInclude)
         cpp.include('yateto.h')
-        if self.arch.backend == 'oneapi':
-            cpp.includeSys('sycl/sycl.hpp')
+        for header in self.arch.headers():
+            cpp.includeSys(header)
         with cpp.PPIfndef('NDEBUG'):
             with cpp.PPIfndef('YATETO_TESTING_NO_FLOP_COUNTER'):
                 cpp('long long libxsmm_num_total_flops = 0;')


### PR DESCRIPTION
In essence, simply generalize the SYCL calls to CUDA/HIP calls.

This PR also renames the "queue" variables in Yateto to "stream"; merely to establish consistency with the rest of the existing Yateto code and the C++ the interface.
