### PR TITLE
Meta Kernel Generation

### DIFF
--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -795,6 +795,12 @@ class InitializerGenerator(object):
       with header.Namespace(namespace), header.Namespace(self.INIT_NAMESPACE):
         for (base_name, base_name_without_namespace), tensors in tensor_dict.items():
           self._init(header, base_name, base_name_without_namespace, '', tensors, False)
+    for namespace, scalar_dict in self.iterate_collect_scalar():
+      with header.Namespace(namespace), header.Namespace(self.INIT_NAMESPACE):
+        for (baseName, baseNameWithoutNamespace), scalars in scalar_dict.items():
+          with header.Struct('{0} : {1}::{0}'.format(baseNameWithoutNamespace, self.TENSOR_NAMESPACE)):
+            # empty forward declaration
+            pass
 
   def generateInitCpp(self, cpp):
     for namespace, tensor_dict in self.iterate_collect():

--- a/yateto/generator.py
+++ b/yateto/generator.py
@@ -455,7 +455,13 @@ class Generator(object):
       cpp.include(fInit.hName)
       with cpp.Namespace(namespace):
         initGen.generateInitCpp(cpp)
-
+    
+    prefixnsp = lambda a: a.name if a.namespace == '' else f'{a.namespace}::{a.name}'
+    return {
+      'namespace': namespace,
+      'tensors': set(tensor.baseNameWithNamespace() for tensor in tensors.values()) | set(scalar.baseNameWithNamespace() for scalar in scalars),
+      'kernels': set(prefixnsp(kernel) for kernel in self._kernels) | set(prefixnsp(family) for family in self._kernelFamilies.values())
+    }
 
 class NamespacedGenerator(object):
   def __init__(self, generator, namespace):

--- a/yateto/metagen.py
+++ b/yateto/metagen.py
@@ -1,4 +1,6 @@
+from .arch import fixArchitectureGlobal
 from .codegen.code import Cpp
+
 import os
 
 class MetaGenerator:
@@ -34,6 +36,8 @@ class MetaGenerator:
             template = gendata['template']
             args = gendata['args']
             kwargs = gendata['kwargs']
+
+            fixArchitectureGlobal(generator._arch)
             result = generator.generate(*args, **kwargs, namespace=subnamespace, outputDir=outdir)
 
             for tensor in result['tensors']:

--- a/yateto/metagen.py
+++ b/yateto/metagen.py
@@ -15,9 +15,14 @@ class MetaGenerator:
             'kwargs': kwargs
         }]
     
-    def generate(self, outputDir='', namespace='yateto', includes=[]):
+    def generate(self, outputDir='', namespace='yateto', includes=[], declarationsTensors=[], declarationsKernels=[]):
         tensors = {}
         kernels = {}
+
+        for tensor in declarationsTensors:
+            tensors[tensor] = []
+        for tensor in declarationsKernels:
+            kernels[tensor] = []
 
         namespacepfx = 'yatetometagen'
         for i, gendata in enumerate(self.generators):
@@ -30,6 +35,7 @@ class MetaGenerator:
             args = gendata['args']
             kwargs = gendata['kwargs']
             result = generator.generate(*args, **kwargs, namespace=subnamespace, outputDir=outdir)
+
             for tensor in result['tensors']:
                 if tensor not in tensors:
                     tensors[tensor] = []
@@ -106,7 +112,7 @@ class MetaGenerator:
             templateargs = ', '.join(f'Arg{i}' for i, _ in enumerate(self.templateType))
             
             with header.Namespace('internal'):
-                header(f'template<{templatetypes}> struct {internalName};')
+                header(f'template<{templatetypes}> struct {internalName} {"{"} using Type = void; {"}"};')
                 for gnsp, spec in foundin:
                     spectext = ', '.join(str(specpart) for specpart in spec)
                     header(f'template<> struct {internalName}<{spectext}> {"{"} using Type = ::{gnsp}::{fullname}; {"}"};')

--- a/yateto/metagen.py
+++ b/yateto/metagen.py
@@ -15,7 +15,7 @@ class MetaGenerator:
             'kwargs': kwargs
         }]
     
-    def generate(self, outputDir='', namespace='yateto'):
+    def generate(self, outputDir='', namespace='yateto', includes=[]):
         tensors = {}
         kernels = {}
 
@@ -42,6 +42,8 @@ class MetaGenerator:
         # TODO: open meta header
         with Cpp(os.path.join(outputDir, 'tensor.h')) as header:
             with header.HeaderGuard('METAGEN_TENSOR_H_'):
+                for path in includes:
+                    header.include(path)
                 for i, gendata in enumerate(self.generators):
                     header.include(f'metagen{i}/tensor.h')
                 with header.Namespace(namespace):
@@ -50,6 +52,8 @@ class MetaGenerator:
         
         with Cpp(os.path.join(outputDir, 'init.h')) as header:
             with header.HeaderGuard('METAGEN_INIT_H_'):
+                for path in includes:
+                    header.include(path)
                 for i, gendata in enumerate(self.generators):
                     header.include(f'metagen{i}/init.h')
                 with header.Namespace(namespace):
@@ -58,6 +62,8 @@ class MetaGenerator:
         
         with Cpp(os.path.join(outputDir, 'kernel.h')) as header:
             with header.HeaderGuard('METAGEN_KERNEL_H_'):
+                for path in includes:
+                    header.include(path)
                 for i, gendata in enumerate(self.generators):
                     header.include(f'metagen{i}/kernel.h')
                 with header.Namespace(namespace):
@@ -75,6 +81,10 @@ class MetaGenerator:
         with Cpp(os.path.join(outputDir, 'kernel.cpp')) as header:
             for i, gendata in enumerate(self.generators):
                 header.include(f'metagen{i}/kernel.cpp')
+        
+        with Cpp(os.path.join(outputDir, 'test-kernels.cpp')) as header:
+            for i, gendata in enumerate(self.generators):
+                header.include(f'metagen{i}/test-kernels.cpp')
         
     def namespacing(self, header, spaces, inner):
         if len(spaces) == 0:

--- a/yateto/metagen.py
+++ b/yateto/metagen.py
@@ -7,17 +7,56 @@ class MetaGenerator:
     def __init__(self, templateType):
         self.templateType = templateType
         self.generators = []
-    
+
     def add_generator(self, template, generator, *args, **kwargs):
         assert len(self.templateType) == len(template)
         self.generators += [{
+            'name': kwargs["name"] if "name" in kwargs else str(len(self.generators)),
             'template': template,
             'generator': generator,
             'args': args,
             'kwargs': kwargs
         }]
-    
-    def generate(self, outputDir='', namespace='yateto', includes=[], declarationsTensors=[], declarationsKernels=[]):
+
+    def compile_list(self):
+        outfiles = []
+        for gendata in self.generators:
+            outdirname = f'metagen_{gendata["name"]}'
+            outdir = os.path.join(outputDir, outdirname)
+
+            genout = []
+            for file in ['tensor', 'init', 'kernel', 'test-kernel']:
+                genout += [file]
+            outfiles += [genout]
+        return outfiles
+
+    def generate_single(self, index, outputDir='', namespace='yateto'):
+        namespacepfx = 'yatetometagen'
+        gendata = self.generators[index]
+        subnamespace = f'{namespace}::{namespacepfx}_{gendata["name"]}'
+        outdirname = f'metagen_{gendata["name"]}'
+        outdir = os.path.join(outputDir, outdirname)
+        os.makedirs(outdir, exist_ok=True)
+
+        generator = gendata['generator']
+        template = gendata['template']
+        args = gendata['args']
+        kwargs = gendata['kwargs']
+
+        fixArchitectureGlobal(generator._arch)
+        result = generator.generate(*args, **kwargs, namespace=subnamespace, outputDir=outdir)
+
+        tensors = {}
+        kernels = {}
+
+        for tensor in result['tensors']:
+            tensors[tensor] = (subnamespace, template)
+        for kernel in result['kernels']:
+            kernels[kernel] = (subnamespace, template)
+
+        return tensors, kernels
+
+    def generate(self, outputDir='', namespace='yateto', includes=[], declarationsTensors=[], declarationsKernels=[], precompiled=None):
         tensors = {}
         kernels = {}
 
@@ -26,28 +65,20 @@ class MetaGenerator:
         for tensor in declarationsKernels:
             kernels[tensor] = []
 
-        namespacepfx = 'yatetometagen'
-        for i, gendata in enumerate(self.generators):
-            subnamespace = f'{namespace}::{namespacepfx}{i}'
-            outdir = os.path.join(outputDir, f'metagen{i}')
-            os.makedirs(outdir, exist_ok=True)
+        for index in range(len(self.generators)):
+            if precompiled is None:
+                local_tensors, local_kernels = self.generate_single(index, outputDir, namespace)
+            else:
+                local_tensors, local_kernels = precompiled[index]
 
-            generator = gendata['generator']
-            template = gendata['template']
-            args = gendata['args']
-            kwargs = gendata['kwargs']
-
-            fixArchitectureGlobal(generator._arch)
-            result = generator.generate(*args, **kwargs, namespace=subnamespace, outputDir=outdir)
-
-            for tensor in result['tensors']:
+            for tensor in local_tensors:
                 if tensor not in tensors:
                     tensors[tensor] = []
-                tensors[tensor] += [(subnamespace, template)]
-            for kernel in result['kernels']:
+                tensors[tensor] += [local_tensors[tensor]]
+            for kernel in local_kernels:
                 if kernel not in kernels:
                     kernels[kernel] = []
-                kernels[kernel] += [(subnamespace, template)]
+                kernels[kernel] += [local_kernels[kernel]]
 
         nspuppercase = namespace.upper()
 
@@ -57,8 +88,9 @@ class MetaGenerator:
                 with header.HeaderGuard(f'METAGEN_{nspuppercase}_{upper}_H_'):
                     for path in includes:
                         header.include(path)
-                    for i, gendata in enumerate(self.generators):
-                        header.include(f'metagen{i}/{name}.h')
+                    for gendata in self.generators:
+                        outdirname = f'metagen_{gendata["name"]}'
+                        header.include(f'{outdirname}/{name}.h')
                     with header.Namespace(namespace):
                         for entry in data:
                             self.template(header, entry, data[entry], f'{name}')
@@ -70,14 +102,15 @@ class MetaGenerator:
 
         def cppForward(name):
             with Cpp(os.path.join(outputDir, f'{name}.cpp')) as header:
-                for i, gendata in enumerate(self.generators):
-                    header.include(f'metagen{i}/{name}.cpp')
+                for gendata in self.generators:
+                    outdirname = f'metagen_{gendata["name"]}'
+                    header.include(f'{outdirname}/{name}.cpp')
         
         cppForward('tensor')
         cppForward('init')
         cppForward('kernel')
         cppForward('test-kernel')
-        
+
     def namespacing(self, header, spaces, inner):
         if len(spaces) == 0:
             inner()

--- a/yateto/metagen.py
+++ b/yateto/metagen.py
@@ -18,7 +18,7 @@ class MetaGenerator:
             'kwargs': kwargs
         }]
 
-    def compile_list(self):
+    def compile_list(self, outputDir=''):
         outfiles = []
         for gendata in self.generators:
             outdirname = f'metagen_{gendata["name"]}'
@@ -43,7 +43,7 @@ class MetaGenerator:
         args = gendata['args']
         kwargs = gendata['kwargs']
 
-        fixArchitectureGlobal(generator._arch)
+        fixArchitectureGlobal(generator.arch())
         result = generator.generate(*args, **kwargs, namespace=subnamespace, outputDir=outdir)
 
         tensors = {}
@@ -120,6 +120,8 @@ class MetaGenerator:
 
     def template(self, header, prename, foundin, subnsp):
         splitname = prename.split('::')
+
+        assert len(splitname) > 0
 
         def inner():
             name = splitname[-1]


### PR DESCRIPTION
Add a way to call Yateto multiple times in a row with different configurations and template the kernels and tensors by call.
Subroutine caching needs to be done externally still (cf. #80 ; can be done with the datastructures introduced there).

Can be e.g. used to disambiguate kernels by precision or even more (like, e.g. convergence order or material class).
Needed for https://github.com/SeisSol/SeisSol/pull/1421 and maybe others to come.
