### PR TITLE
Add const tensor views

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ applications. You can find much more information about the package
 [here](https://arxiv.org/abs/1903.11521).
 
 ## Installation
+
 ```bash
 pip install -e .
 ```
 
+or include it into your project as a submodule.
+
 ## Usage
+
 ```python
 from yateto import *
 
@@ -28,7 +32,8 @@ def add(g):
 arch = useArchitectureIdentifiedBy("dhsw")
 generator = Generator(arch)
 add(generator)
-generator.generate(output_dir, GeneratorCollection([LIBXSMM(arch), Eigen(arch)]))
+generator.generate(output_dir, gemm_cfg=GeneratorCollection([LIBXSMM(arch), Eigen(arch)]))
 ...
 ```
 
+Note that the interfaces Yateto generates require C++17.

--- a/include/yateto/TensorView.h
+++ b/include/yateto/TensorView.h
@@ -22,7 +22,7 @@ namespace yateto {
   template<typename uint_t, typename... Entry>
   struct count_slices : std::integral_constant<uint_t,0> {};
   template<typename uint_t, typename Head, typename... Tail>
-  struct count_slices<uint_t, Head, Tail...> : std::integral_constant<uint_t, ((std::is_same<Head, slice<uint_t>>::value) ? 1 : 0) + count_slices<uint_t, Tail...>::value> {};
+  struct count_slices<uint_t, Head, Tail...> : std::integral_constant<uint_t, ((std::is_same_v<Head, slice<uint_t>>) ? 1 : 0) + count_slices<uint_t, Tail...>::value> {};
 
   template<unsigned Dim, typename real_t, typename uint_t>
   class TensorView {
@@ -65,23 +65,23 @@ namespace yateto {
     }
   };
 
-  template<unsigned Dim, typename real_t, typename uint_t=unsigned>
+  template<unsigned Dim, typename real_t, typename uint_t=unsigned, typename data_t=real_t*>
   class DenseTensorView : public TensorView<Dim, real_t, uint_t> {
   public:
-    explicit DenseTensorView(real_t* values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
+    explicit DenseTensorView(data_t values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values) {
       std::copy(start.begin(), start.end(), m_start);
       std::copy(stop.begin(), stop.end(), m_stop);
       computeStride();
     }
 
-    explicit DenseTensorView(real_t* values, std::initializer_list<uint_t> shape)
+    explicit DenseTensorView(data_t values, std::initializer_list<uint_t> shape)
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values), m_start{} {
       std::copy(shape.begin(), shape.end(), m_stop);
       computeStride();
     }
 
-    explicit DenseTensorView(real_t* values, uint_t const shape[], uint_t const start[], uint_t const stop[])
+    explicit DenseTensorView(data_t values, uint_t const shape[], uint_t const start[], uint_t const stop[])
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values) {
       for (uint_t d = 0; d < Dim; ++d) {
         m_start[d] = start[d];
@@ -90,7 +90,7 @@ namespace yateto {
       computeStride();
     }
 
-    explicit DenseTensorView(real_t* values, uint_t const shape[])
+    explicit DenseTensorView(data_t values, uint_t const shape[])
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values), m_start{} {
       for (uint_t d = 0; d < Dim; ++d) {
         m_stop[d] = shape[d];
@@ -98,7 +98,7 @@ namespace yateto {
       computeStride();
     }
  
-    explicit DenseTensorView(real_t* values, uint_t const shape[], uint_t const stride[])
+    explicit DenseTensorView(data_t values, uint_t const shape[], uint_t const stride[])
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values), m_start{} {
       for (uint_t d = 0; d < Dim; ++d) {
         m_stop[d] = shape[d];
@@ -195,7 +195,7 @@ namespace yateto {
       }
       
       uint_t stop0 = std::min(m_stop[0], this->shape(0));
-      real_t* val = m_values;
+      data_t val = m_values;
       while (entry[Dim-1] != m_stop[Dim-1]) {
         for (uint_t i = m_start[0]; i < stop0; ++i) {
           entry[0] = i;
@@ -228,7 +228,7 @@ namespace yateto {
       return subtensor;
     }
 
-    real_t* data() {
+    auto data() {
       return m_values;
     }
 
@@ -257,13 +257,13 @@ namespace yateto {
       return (head - m_start[d]) * m_stride[d] + address(tail...);
     }
 
-    template<typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+    template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
     void extractDim(uint_t*& begin, uint_t*&, uint_t*&, uint_t dimNo, T entry) const {
       assert(static_cast<uint_t>(entry) >= m_start[dimNo] && static_cast<uint_t>(entry) < m_stop[dimNo]);
       *begin++ = entry;
     }
 
-    template<typename T, typename std::enable_if<std::is_same<T, slice<uint_t>>::value, int>::type = 0>
+    template<typename T, std::enable_if_t<std::is_same_v<T, slice<uint_t>>, int> = 0>
     void extractDim(uint_t*& begin, uint_t*& size, uint_t*& stride, uint_t dimNo, T dim) const {
       *begin = std::max(m_start[dimNo], dim.start);
       *size++ = std::min(m_stop[dimNo], dim.stop) - *begin;
@@ -283,16 +283,16 @@ namespace yateto {
       extractSubtensor(begin, size, stride, tail...);
     }
 
-    real_t* m_values;
+    data_t m_values;
     uint_t m_start[Dim];
     uint_t m_stop[Dim];
     uint_t m_stride[Dim];
   };
 
-  template<typename real_t, typename uint_t>
-  class DenseTensorView<0,real_t,uint_t> : public TensorView<0, real_t, uint_t> {
+  template<typename real_t, typename uint_t, typename data_t>
+  class DenseTensorView<0,real_t,uint_t,data_t> : public TensorView<0, real_t, uint_t> {
   public:
-    explicit DenseTensorView(real_t* values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
+    explicit DenseTensorView(data_t values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
       : TensorView<0, real_t, uint_t>(shape), m_values(values) {
     }
 
@@ -310,17 +310,17 @@ namespace yateto {
     }
 
   protected:
-    real_t* m_values;
+    data_t m_values;
   };
 
-  template<typename real_t, typename uint_t>
+  template<typename real_t, typename uint_t, typename data_t=real_t*>
   class CSCMatrixView : public TensorView<2, real_t, uint_t> {
   public:
-    explicit CSCMatrixView(real_t* values, std::initializer_list<uint_t> shape, uint_t const* rowInd, uint_t const* colPtr)
+    explicit CSCMatrixView(data_t values, std::initializer_list<uint_t> shape, uint_t const* rowInd, uint_t const* colPtr)
       : TensorView<2, real_t, uint_t>(shape), m_values(values), m_rowInd(rowInd), m_colPtr(colPtr) {
     }
 
-    explicit CSCMatrixView(real_t* values, uint_t const shape[], uint_t const* rowInd, uint_t const* colPtr)
+    explicit CSCMatrixView(data_t values, uint_t const shape[], uint_t const* rowInd, uint_t const* colPtr)
       : TensorView<2, real_t, uint_t>(shape), m_values(values), m_rowInd(rowInd), m_colPtr(colPtr) {
     }
 
@@ -401,7 +401,7 @@ namespace yateto {
     }
 
   protected:
-    real_t* m_values;
+    data_t m_values;
     uint_t const* m_rowInd;
     uint_t const* m_colPtr;
   };

--- a/include/yateto/TensorView.h
+++ b/include/yateto/TensorView.h
@@ -66,10 +66,11 @@ namespace yateto {
     }
   };
 
-  template<unsigned Dim, typename real_t, typename uint_t=unsigned, typename data_t=real_t*>
+  template<unsigned Dim, typename real_t, typename uint_t=unsigned, bool Const = false>
   class DenseTensorView : public TensorView<Dim, real_t, uint_t> {
   public:
-    static_assert(std::is_same_v<typename std::iterator_traits<data_t>::value_type, real_t>, "data_t iterator value type and real_t do not match");
+    using data_t = std::conditional_t<Const, const real_t*, real_t*>;
+    using dataref_t = std::conditional_t<Const, const real_t&, real_t&>;
 
     explicit DenseTensorView(data_t values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
       : TensorView<Dim, real_t, uint_t>(shape), m_values(values) {
@@ -154,7 +155,7 @@ namespace yateto {
     }
 
     template<typename... Entry>
-    typename std::iterator_traits<data_t>::reference operator()(Entry... entry) {
+    dataref_t operator()(Entry... entry) {
       static_assert(sizeof...(entry) == Dim,
                         "Number of arguments to operator() does not match the tensor dimension.");
       assert(isInRange(entry...));
@@ -178,7 +179,7 @@ namespace yateto {
       return m_values[addr];
     }
 
-    typename std::iterator_traits<data_t>::reference operator[](uint_t const entry[Dim]) {
+    dataref_t operator[](uint_t const entry[Dim]) {
       uint_t addr = 0;
       for (uint_t d = 0; d < Dim; ++d) {
         assert(entry[d] >= m_start[d] && entry[d] < m_stop[d]);
@@ -220,18 +221,30 @@ namespace yateto {
     }
 
     template<typename... Entry>
-    auto subtensor(Entry... entry) -> DenseTensorView<count_slices<uint_t, Entry...>::value, real_t, uint_t, data_t> const {
+    auto subtensor(Entry... entry) -> DenseTensorView<count_slices<uint_t, Entry...>::value, real_t, uint_t, Const> {
       static_assert(sizeof...(entry) == Dim, "Number of arguments to subtensor() does not match tensor dimension.");
       constexpr auto nSlices = count_slices<uint_t, Entry...>::value;
       uint_t begin[Dim];
       uint_t size[nSlices];
       uint_t stride[nSlices];
       extractSubtensor(begin, size, stride, entry...);
-      DenseTensorView<nSlices, real_t, uint_t> subtensor(&operator[](begin), size, stride);
+      DenseTensorView<nSlices, real_t, uint_t, Const> subtensor(&operator[](begin), size, stride);
       return subtensor;
     }
 
-    auto data() {
+    template<typename... Entry>
+    auto subtensor(Entry... entry) const -> DenseTensorView<count_slices<uint_t, Entry...>::value, real_t, uint_t, true> {
+      static_assert(sizeof...(entry) == Dim, "Number of arguments to subtensor() does not match tensor dimension.");
+      constexpr auto nSlices = count_slices<uint_t, Entry...>::value;
+      uint_t begin[Dim];
+      uint_t size[nSlices];
+      uint_t stride[nSlices];
+      extractSubtensor(begin, size, stride, entry...);
+      DenseTensorView<nSlices, real_t, uint_t, true> subtensor(&operator[](begin), size, stride);
+      return subtensor;
+    }
+
+    data_t data() {
       return m_values;
     }
 
@@ -292,9 +305,12 @@ namespace yateto {
     uint_t m_stride[Dim];
   };
 
-  template<typename real_t, typename uint_t, typename data_t>
-  class DenseTensorView<0,real_t,uint_t,data_t> : public TensorView<0, real_t, uint_t> {
+  template<typename real_t, typename uint_t, bool Const>
+  class DenseTensorView<0,real_t,uint_t,Const> : public TensorView<0, real_t, uint_t> {
   public:
+    using data_t = std::conditional_t<Const, const real_t*, real_t*>;
+    using dataref_t = std::conditional_t<Const, const real_t&, real_t&>;
+
     explicit DenseTensorView(data_t values, std::initializer_list<uint_t> shape, std::initializer_list<uint_t> start, std::initializer_list<uint_t> stop)
       : TensorView<0, real_t, uint_t>(shape), m_values(values) {
     }
@@ -316,10 +332,11 @@ namespace yateto {
     data_t m_values;
   };
 
-  template<typename real_t, typename uint_t, typename data_t=real_t*>
+  template<typename real_t, typename uint_t, bool Const = false>
   class CSCMatrixView : public TensorView<2, real_t, uint_t> {
   public:
-    static_assert(std::is_same_v<typename std::iterator_traits<data_t>::value_type, real_t>, "data_t iterator value type and real_t do not match");
+    using data_t = std::conditional_t<Const, const real_t*, real_t*>;
+    using dataref_t = std::conditional_t<Const, const real_t&, real_t&>;
 
     explicit CSCMatrixView(data_t values, std::initializer_list<uint_t> shape, uint_t const* rowInd, uint_t const* colPtr)
       : TensorView<2, real_t, uint_t>(shape), m_values(values), m_rowInd(rowInd), m_colPtr(colPtr) {
@@ -352,7 +369,7 @@ namespace yateto {
       return m_values[addr];
     }
 
-    typename std::iterator_traits<data_t>::reference operator()(uint_t row, uint_t col) {
+    dataref_t operator()(uint_t row, uint_t col) {
       assert(col >= 0 && col < this->shape(1));
       uint_t addr = m_colPtr[ col ];
       uint_t stop = m_colPtr[ col+1 ];
@@ -381,7 +398,7 @@ namespace yateto {
       return false;
     }
 
-    typename std::iterator_traits<data_t>::reference operator[](const uint_t entry[2]) {
+    dataref_t operator[](const uint_t entry[2]) {
       return operator()(entry[0], entry[1]);
     }
 

--- a/include/yateto/TensorView.h
+++ b/include/yateto/TensorView.h
@@ -163,14 +163,14 @@ namespace yateto {
     }
 
     template<typename... Entry>
-    real_t operator()(Entry... entry) const {
+    const real_t& operator()(Entry... entry) const {
       static_assert(sizeof...(entry) == Dim,
                         "Number of arguments to operator() const does not match the tensor dimension.");
       assert(isInRange(entry...));
       return m_values[address(entry...)];
     }
 
-    real_t operator[](uint_t const entry[Dim]) const {
+    const real_t& operator[](uint_t const entry[Dim]) const {
       uint_t addr = 0;
       for (uint_t d = 0; d < Dim; ++d) {
         assert(entry[d] >= m_start[d] && entry[d] < m_stop[d]);
@@ -354,7 +354,7 @@ namespace yateto {
       memset(m_values, 0, size() * sizeof(real_t));
     }
 
-    real_t operator()(uint_t row, uint_t col) const {
+    const real_t& operator()(uint_t row, uint_t col) const {
       assert(col >= 0 && col < this->shape(1));
       uint_t addr = m_colPtr[ col ];
       uint_t stop = m_colPtr[ col+1 ];
@@ -402,7 +402,7 @@ namespace yateto {
       return operator()(entry[0], entry[1]);
     }
 
-    real_t operator[](const uint_t entry[2]) const {
+    const real_t& operator[](const uint_t entry[2]) const {
       return operator()(entry[0], entry[1]);
     }
 

--- a/tests/interface/CMakeLists.txt
+++ b/tests/interface/CMakeLists.txt
@@ -3,6 +3,10 @@ project(inteface-test)
 
 find_package(CxxTest REQUIRED)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 enable_testing()
 # generate and add an interface test
  add_custom_command(COMMAND ${CXXTEST_PYTHON_TESTGEN_EXECUTABLE} 
@@ -12,5 +16,4 @@ enable_testing()
 
 add_executable(tensor-view-target TensorView.t.cpp)
 target_include_directories(tensor-view-target PUBLIC ${CMAKE_SOURCE_DIR}/../../include ${CXXTEST_INCLUDE_DIRS})
-target_compile_options(tensor-view-target PUBLIC "-std=c++11")
 add_test(tensor-view tensor-view-target)

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -637,8 +637,8 @@ class InitializerGenerator(object):
     ARGUMENT_NAME = 'values'
 
     def typename(self, dim, arch, const):
-      dtype = f'{arch.typename} const*' if const else f'{arch.typename} *'
-      return '::{}::{}<{},{},{},{}>'.format(SUPPORT_LIBRARY_NAMESPACE, type(self).__name__, dim, arch.typename, arch.uintTypename, dtype)
+      constStr = 'true' if const else 'false'
+      return '::{}::{}<{},{},{},{}>'.format(SUPPORT_LIBRARY_NAMESPACE, type(self).__name__, dim, arch.typename, arch.uintTypename, constStr)
     
     @classmethod
     def arguments(cls, arch, const):
@@ -682,8 +682,8 @@ class InitializerGenerator(object):
     COLPTR_NAME = 'ColPtr'
     
     def typename(self, dim, arch, const):
-      dtype = f'{arch.typename} const*' if const else f'{arch.typename} *'
-      return '::{}::{}<{},{},{}>'.format(SUPPORT_LIBRARY_NAMESPACE, type(self).__name__, arch.typename, arch.uintTypename, dtype)
+      constStr = 'true' if const else 'false'
+      return '::{}::{}<{},{},{}>'.format(SUPPORT_LIBRARY_NAMESPACE, type(self).__name__, arch.typename, arch.uintTypename, constStr)
 
     def generate(self, cpp, memLayout, arch, index, const):
       cpp( 'return {}({}, {}, {}, {});'.format(


### PR DESCRIPTION
Add tensor views on `const` pointers; i.e. immutable tensor views; thus eliminating the need for casting away the `const` when e.g. creating a view on the given matrix values.

Not 100%ly confident yet about the implementation (e.g. the `const` could be made a template bool instead), but it works well right now already.
