### PR TITLE
Add end-to-end tests for kernel families, fix max temp memory function existence

### DIFF
--- a/tests/code-gen/family.py
+++ b/tests/code-gen/family.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from yateto import *
+
+def add(g):
+  N = 4
+  A = Tensor("A", (N, N))
+  B = Tensor("B", (N, N))
+  C = Tensor("C", (N, N))
+
+  def build(i):
+      return C["ij"] <= A["ik"] * B["kj"]
+
+  g.addFamily("family0p", simpleParameterSpace(), build)
+  g.addFamily("family1p", simpleParameterSpace(2), build)
+  g.addFamily("family2p", simpleParameterSpace(2, 3), build)
+  g.addFamily("family3p", simpleParameterSpace(2, 3, 4), build)
+
+  g.addFamily("family1px", parameterSpaceFromRanges(range(1, 10, 2)), build)
+  g.addFamily("family2px", parameterSpaceFromRanges(range(1, 10, 2), range(10, 20, 3)), build)

--- a/yateto/codegen/visitor.py
+++ b/yateto/codegen/visitor.py
@@ -404,8 +404,7 @@ class OptimizedKernelGenerator(KernelGenerator):
                           self.INBOUND_CONST_BYTES_NAME,
                           self.INBOUND_BYTES_NAME,
                           self.OUTBOUND_BYTES_NAME,
-                          self.TEMP_MEM_REQUIRED_NAME,
-                          self.TEMP_MAX_MEM_REQUIRED_NAME]
+                          self.TEMP_MEM_REQUIRED_NAME]
 
         for function in aux_functions:
           funName = function[:1].lower() + function[1:]


### PR DESCRIPTION
One small oversight from #114 ; namely the max temp memory is never parametrized but always a scalar. But the CI didn't trigger for a failure (only SeisSol did later on).
So we add some kernel family e2e tests to make sure it doesn't happen again.
